### PR TITLE
Allow moving interventions across days

### DIFF
--- a/src/main/java/com/materiel/client/model/Resource.java
+++ b/src/main/java/com/materiel/client/model/Resource.java
@@ -1,7 +1,5 @@
 package com.materiel.client.model;
 
-import java.time.LocalDateTime;
-
 /**
  * Modèle pour les ressources (grues, camions, etc.)
  */
@@ -61,9 +59,22 @@ public class Resource {
     
     public String getSpecifications() { return specifications; }
     public void setSpecifications(String specifications) { this.specifications = specifications; }
-    
+
     @Override
     public String toString() {
         return nom + " (" + type.getDisplayName() + ")";
     }
-} 
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof Resource)) return false;
+        Resource other = (Resource) obj;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+}

--- a/src/main/java/com/materiel/client/view/components/InterventionCard.java
+++ b/src/main/java/com/materiel/client/view/components/InterventionCard.java
@@ -5,6 +5,8 @@ import com.materiel.client.model.Resource;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.dnd.*;
+import java.awt.datatransfer.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.time.format.DateTimeFormatter;
@@ -13,12 +15,14 @@ import java.util.stream.Collectors;
 /**
  * Carte d'intervention améliorée avec design riche et informations complètes
  */
-public class InterventionCard extends JPanel {
+public class InterventionCard extends JPanel implements DragGestureListener, DragSourceListener {
     
     private final Intervention intervention;
     private boolean hovered = false;
     private boolean selected = false;
     private boolean highlighted = false; // Pour le feedback DnD
+    private boolean dragging = false;
+    private DragSource dragSource;
     
     // Constantes de design
     private static final Color BACKGROUND_NORMAL = Color.WHITE;
@@ -35,6 +39,7 @@ public class InterventionCard extends JPanel {
         this.intervention = intervention;
         initComponents();
         setupEventHandlers();
+        setupDragAndDrop();
     }
     
     private void initComponents() {
@@ -320,8 +325,12 @@ public class InterventionCard extends JPanel {
         Color backgroundColor;
         Color borderColor;
         int borderWidth;
-        
-        if (highlighted) {
+
+        if (dragging) {
+            backgroundColor = BACKGROUND_HOVER;
+            borderColor = Color.decode("#3B82F6");
+            borderWidth = 2;
+        } else if (highlighted) {
             backgroundColor = BACKGROUND_HIGHLIGHT;
             borderColor = Color.decode("#F59E0B"); // Orange pour highlight DnD
             borderWidth = 3;
@@ -346,6 +355,51 @@ public class InterventionCard extends JPanel {
         ));
         
         repaint();
+    }
+
+    private void setupDragAndDrop() {
+        dragSource = new DragSource();
+        dragSource.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_MOVE, this);
+    }
+
+    // Implémentation DragGestureListener
+    @Override
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        if (intervention.getId() == null) {
+            return;
+        }
+        dragging = true;
+        updateAppearance();
+
+        String transferData = "INTERVENTION:" + intervention.getId();
+        StringSelection transferable = new StringSelection(transferData);
+
+        try {
+            dragSource.startDrag(dge, DragSource.DefaultMoveDrop, transferable, this);
+        } catch (Exception e) {
+            dragging = false;
+            updateAppearance();
+            e.printStackTrace();
+        }
+    }
+
+    // Implémentation DragSourceListener
+    @Override
+    public void dragEnter(DragSourceDragEvent dsde) { }
+
+    @Override
+    public void dragOver(DragSourceDragEvent dsde) { }
+
+    @Override
+    public void dropActionChanged(DragSourceDragEvent dsde) { }
+
+    @Override
+    public void dragExit(DragSourceEvent dse) { }
+
+    @Override
+    public void dragDropEnd(DragSourceDropEvent dsde) {
+        dragging = false;
+        updateAppearance();
     }
     
     /**

--- a/src/main/java/com/materiel/client/view/planning/PlanningPanel.java
+++ b/src/main/java/com/materiel/client/view/planning/PlanningPanel.java
@@ -19,6 +19,7 @@ import java.awt.datatransfer.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -337,7 +338,7 @@ public class PlanningPanel extends JPanel {
                 if (!interventionDate.isBefore(currentWeekStart) && 
                     !interventionDate.isAfter(currentWeekStart.plusDays(6))) {
                     
-                    int dayIndex = (int) currentWeekStart.until(interventionDate).getDays();
+                    int dayIndex = (int) ChronoUnit.DAYS.between(currentWeekStart, interventionDate);
                     
                     // Ajouter l'intervention à toutes les cellules des ressources impliquées
                     for (Resource resource : intervention.getRessources()) {
@@ -387,7 +388,7 @@ public class PlanningPanel extends JPanel {
             if (!interventionDate.isBefore(currentWeekStart) && 
                 !interventionDate.isAfter(currentWeekStart.plusDays(6))) {
                 
-                int dayIndex = (int) currentWeekStart.until(interventionDate).getDays();
+                int dayIndex = (int) ChronoUnit.DAYS.between(currentWeekStart, interventionDate);
                 
                 for (Resource resource : intervention.getRessources()) {
                     int resourceIndex = resources.indexOf(resource);
@@ -584,12 +585,19 @@ public class PlanningPanel extends JPanel {
                     String data = (String) transferable.getTransferData(DataFlavor.stringFlavor);
                     System.out.println("🔧 DEBUG: Données reçues: " + data);
                     
-                    // Parser les données : "RESOURCE:id:nom:type"
+                    // Parser les données : "RESOURCE:id:nom:type" ou "INTERVENTION:id"
                     String[] parts = data.split(":");
-                    if (parts.length >= 3 && "RESOURCE".equals(parts[0])) {
+                    if (parts.length >= 2 && "INTERVENTION".equals(parts[0])) {
+                        Long interventionId = Long.parseLong(parts[1]);
+                        System.out.println("🔧 DEBUG: Tentative de déplacement pour intervention ID: " + interventionId);
+
+                        handleInterventionDrop(interventionId);
+                        dtde.getDropTargetContext().dropComplete(true);
+                        System.out.println("✅ Intervention déplacée avec succès");
+                    } else if (parts.length >= 3 && "RESOURCE".equals(parts[0])) {
                         Long resourceId = Long.parseLong(parts[1]);
                         System.out.println("🔧 DEBUG: Tentative de drop pour ressource ID: " + resourceId);
-                        
+
                         handleResourceDrop(resourceId);
                         dtde.getDropTargetContext().dropComplete(true);
                         System.out.println("✅ Drop traité avec succès");
@@ -649,6 +657,48 @@ public class PlanningPanel extends JPanel {
                     e.printStackTrace();
                     JOptionPane.showMessageDialog(PlanningPanel.this,
                         "Erreur lors de la création de l'intervention: " + e.getMessage(),
+                        "Erreur", JOptionPane.ERROR_MESSAGE);
+                }
+            });
+        }
+
+        private void handleInterventionDrop(Long interventionId) {
+            SwingUtilities.invokeLater(() -> {
+                try {
+                    System.out.println("🔧 DEBUG: Déplacement de l'intervention ID: " + interventionId);
+
+                    Intervention movedIntervention = interventions.stream()
+                            .filter(i -> i.getId().equals(interventionId))
+                            .findFirst()
+                            .orElse(null);
+
+                    if (movedIntervention == null) {
+                        System.err.println("🔧 ERROR: Intervention non trouvée avec ID: " + interventionId);
+                        JOptionPane.showMessageDialog(PlanningPanel.this,
+                            "Intervention non trouvée", "Erreur", JOptionPane.ERROR_MESSAGE);
+                        return;
+                    }
+
+                    LocalDate targetDate = targetCell.getDate();
+                    LocalDateTime newStart = LocalDateTime.of(targetDate, movedIntervention.getDateDebut().toLocalTime());
+                    LocalDateTime newEnd = LocalDateTime.of(targetDate, movedIntervention.getDateFin().toLocalTime());
+
+                    movedIntervention.setDateDebut(newStart);
+                    movedIntervention.setDateFin(newEnd);
+
+                    InterventionService interventionService = ServiceFactory.getInterventionService();
+                    interventionService.saveIntervention(movedIntervention);
+
+                    refreshPlanning();
+
+                    JOptionPane.showMessageDialog(PlanningPanel.this,
+                        "Intervention déplacée au " + targetDate,
+                        "Succès", JOptionPane.INFORMATION_MESSAGE);
+                } catch (Exception e) {
+                    System.err.println("🔧 ERROR: Erreur déplacement intervention: " + e.getMessage());
+                    e.printStackTrace();
+                    JOptionPane.showMessageDialog(PlanningPanel.this,
+                        "Erreur lors du déplacement: " + e.getMessage(),
                         "Erreur", JOptionPane.ERROR_MESSAGE);
                 }
             });


### PR DESCRIPTION
## Summary
- place intervention tiles accurately using day differences
- support dragging intervention tiles to new days while keeping their times

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*
- `javac @sources.txt -d out` *(fails: package com.fasterxml.jackson.annotation does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c014466cc0833091c867874670d1c1