### PR TITLE
feat: improve planning layout and interaction

### DIFF
--- a/src/main/java/com/materiel/client/view/planning/TileRenderer.java
+++ b/src/main/java/com/materiel/client/view/planning/TileRenderer.java
@@ -1,0 +1,28 @@
+package com.materiel.client.view.planning;
+
+import com.materiel.client.view.ui.ColorUtils;
+import com.materiel.client.view.ui.ColorUtils.TileColors;
+
+import java.awt.*;
+
+/** Painter used to render intervention tiles. */
+public final class TileRenderer {
+    private TileRenderer() {
+    }
+
+    public static void paint(Graphics2D g2, Rectangle bounds, Color baseColor, String text) {
+        TileColors colors = ColorUtils.deriveTileColors(baseColor);
+        g2.setColor(colors.background());
+        g2.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height,
+                UIConstants.TILE_RADIUS, UIConstants.TILE_RADIUS);
+        g2.setColor(colors.border());
+        g2.setStroke(new BasicStroke(UIConstants.TILE_BORDER_WIDTH));
+        g2.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height,
+                UIConstants.TILE_RADIUS, UIConstants.TILE_RADIUS);
+        g2.setColor(colors.text());
+        FontMetrics fm = g2.getFontMetrics();
+        int tx = bounds.x + UIConstants.TILE_PADDING;
+        int ty = bounds.y + fm.getAscent() + UIConstants.TILE_PADDING;
+        g2.drawString(text, tx, ty);
+    }
+}

--- a/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
+++ b/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
@@ -1,0 +1,52 @@
+package com.materiel.client.view.planning;
+
+import com.materiel.client.view.planning.layout.TimeScaleModel;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
+import java.time.LocalDate;
+
+/** Header displaying day columns aligned with the planning grid. */
+public class TimelineHeader extends JComponent implements ChangeListener {
+    private final TimeScaleModel scale;
+    private JViewport viewport;
+
+    public TimelineHeader(TimeScaleModel scale) {
+        this.scale = scale;
+        setPreferredSize(new Dimension(0, UIConstants.ROW_BASE_HEIGHT));
+    }
+
+    /** Attach this header to the same viewport as the planning board for sync. */
+    public void attachToViewport(JViewport vp) {
+        if (this.viewport != null) {
+            this.viewport.removeChangeListener(this);
+        }
+        this.viewport = vp;
+        if (vp != null) {
+            vp.addChangeListener(this);
+        }
+    }
+
+    public int[] getColumnXs(LocalDate day) {
+        return scale.getColumnXs(day);
+    }
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+        repaint();
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2 = (Graphics2D) g.create();
+        g2.setColor(Color.GRAY);
+        int[] xs = scale.getColumnXs(LocalDate.now());
+        for (int x : xs) {
+            g2.drawLine(x, 0, x, getHeight());
+        }
+        g2.dispose();
+    }
+}

--- a/src/main/java/com/materiel/client/view/planning/UIConstants.java
+++ b/src/main/java/com/materiel/client/view/planning/UIConstants.java
@@ -9,8 +9,20 @@ public final class UIConstants {
     public static final int LEFT_GUTTER_WIDTH = 180;
 
     /** Minimum width of an intervention tile. */
-    public static final int MIN_TILE_WIDTH = 12;
+    public static final int MIN_TILE_WIDTH = 120;
 
-    /** Minimum height of an intervention tile. */
-    public static final int MIN_TILE_HEIGHT = 12;
+    /** Base height of a row representing one hour. */
+    public static final int ROW_BASE_HEIGHT = 88;
+
+    /** Vertical gap between tracks when rows wrap. */
+    public static final int TRACK_V_GUTTER = 6;
+
+    /** Padding inside tiles. */
+    public static final int TILE_PADDING = 6;
+
+    /** Radius of tile corners. */
+    public static final int TILE_RADIUS = 8;
+
+    /** Width of the tile border. */
+    public static final int TILE_BORDER_WIDTH = 1;
 }

--- a/src/main/java/com/materiel/client/view/planning/layout/LaneLayout.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/LaneLayout.java
@@ -1,0 +1,59 @@
+package com.materiel.client.view.planning.layout;
+
+import java.awt.Rectangle;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.materiel.client.model.Intervention;
+import com.materiel.client.view.planning.UIConstants;
+
+/**
+ * Layout helper computing lanes and tracks with wrapping when space is limited.
+ */
+public final class LaneLayout {
+    private LaneLayout() {
+    }
+
+    /** Data describing lane position within tracks. */
+    public static class Lane {
+        public int index;
+        public int count;
+        public int track;
+        public int tracks;
+    }
+
+    /** Compute lanes for interventions. */
+    public static Map<Intervention, Lane> computeLanes(List<Intervention> byResource, int rowUsableWidth) {
+        Map<Intervention, Lane> result = new LinkedHashMap<>();
+        int laneCount = byResource.size();
+        int tracks = (int) Math.ceil((laneCount * (double) UIConstants.MIN_TILE_WIDTH) / rowUsableWidth);
+        tracks = Math.max(tracks, 1);
+        int lanesPerTrack = (int) Math.ceil(laneCount / (double) tracks);
+        for (int i = 0; i < byResource.size(); i++) {
+            Intervention in = byResource.get(i);
+            Lane lane = new Lane();
+            lane.track = i / lanesPerTrack;
+            lane.tracks = tracks;
+            lane.index = i % lanesPerTrack;
+            lane.count = lanesPerTrack;
+            result.put(in, lane);
+        }
+        return result;
+    }
+
+    /** Compute pixel bounds of a tile. */
+    public static Rectangle computeTileBounds(Intervention i, Lane lane, TimeScaleModel scale) {
+        int y1 = scale.timeToY(i.getDateDebut());
+        int y2 = scale.timeToY(i.getDateFin());
+        int height = Math.max(UIConstants.ROW_BASE_HEIGHT, y2 - y1);
+        int trackOffset = lane.track * (UIConstants.ROW_BASE_HEIGHT + UIConstants.TRACK_V_GUTTER);
+        y1 += trackOffset;
+
+        int[] xs = scale.getColumnXs(i.getDateDebut().toLocalDate());
+        int rowUsableWidth = xs[xs.length - 1] - scale.getLeftGutterWidth();
+        int laneWidth = lane.count == 0 ? rowUsableWidth : rowUsableWidth / lane.count;
+        int x = scale.getLeftGutterWidth() + lane.index * laneWidth;
+        return new Rectangle(x, y1, laneWidth, height);
+    }
+}

--- a/src/main/java/com/materiel/client/view/planning/layout/TimeScaleModel.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/TimeScaleModel.java
@@ -1,0 +1,46 @@
+package com.materiel.client.view.planning.layout;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.materiel.client.view.planning.UIConstants;
+
+/** Shared model to translate time and columns into pixel positions. */
+public class TimeScaleModel {
+    private final int hourWidth;
+    private final int leftGutter;
+
+    public TimeScaleModel(int hourWidth) {
+        this.hourWidth = hourWidth;
+        this.leftGutter = UIConstants.LEFT_GUTTER_WIDTH;
+    }
+
+    /**
+     * @param day ignored for now but kept for future multi-day layouts
+     * @return x positions of column boundaries for the given day
+     */
+    public int[] getColumnXs(LocalDate day) {
+        int[] xs = new int[25];
+        xs[0] = leftGutter;
+        for (int h = 1; h <= 24; h++) {
+            xs[h] = leftGutter + h * hourWidth;
+        }
+        return xs;
+    }
+
+    /** Convert time to y position. */
+    public int timeToY(LocalDateTime t) {
+        return t.getHour() * UIConstants.ROW_BASE_HEIGHT;
+    }
+
+    /** Convert y position back to nearest hour. */
+    public LocalDateTime yToTime(int y) {
+        int hour = y / UIConstants.ROW_BASE_HEIGHT;
+        return LocalDateTime.of(LocalDate.now(), LocalTime.of(hour, 0));
+    }
+
+    public int getLeftGutterWidth() {
+        return leftGutter;
+    }
+}

--- a/src/main/java/com/materiel/client/view/ui/ColorUtils.java
+++ b/src/main/java/com/materiel/client/view/ui/ColorUtils.java
@@ -1,0 +1,25 @@
+package com.materiel.client.view.ui;
+
+import java.awt.Color;
+
+/** Utility class for color operations used in planning UI. */
+public final class ColorUtils {
+    private ColorUtils() {
+    }
+
+    /** Holder for derived tile colors. */
+    public record TileColors(Color background, Color border, Color text) {}
+
+    /**
+     * Derive a readable palette from the base color ensuring contrast for text
+     * and a visible border.
+     */
+    public static TileColors deriveTileColors(Color base) {
+        float[] hsb = Color.RGBtoHSB(base.getRed(), base.getGreen(), base.getBlue(), null);
+        Color background = Color.getHSBColor(hsb[0], Math.max(0f, hsb[1] * 0.1f), Math.min(1f, hsb[2] * 1.2f));
+        Color border = Color.getHSBColor(hsb[0], hsb[1], Math.max(0f, hsb[2] * 0.8f));
+        int luminance = (int) (0.299 * background.getRed() + 0.587 * background.getGreen() + 0.114 * background.getBlue());
+        Color text = luminance > 140 ? Color.BLACK : Color.WHITE;
+        return new TileColors(background, border, text);
+    }
+}

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -9,5 +9,5 @@ tooltip.status=Statut: {0}
 tooltip.conflict=Conflit: {0}
 tooltip.no_conflict=aucun
 tooltip.none=n/a
-planning.resources=Resources
-planning.duration=Duration
+planning.resources=Ressources
+planning.duration=Durée

--- a/src/test/java/com/materiel/client/view/planning/HeaderAlignmentTest.java
+++ b/src/test/java/com/materiel/client/view/planning/HeaderAlignmentTest.java
@@ -1,0 +1,21 @@
+package com.materiel.client.view.planning;
+
+import com.materiel.client.view.planning.layout.TimeScaleModel;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class HeaderAlignmentTest {
+    @Test
+    void headerAndBoardShareSameColumns() {
+        TimeScaleModel model = new TimeScaleModel(100);
+        TimelineHeader header = new TimelineHeader(model);
+        PlanningBoard board = new PlanningBoard();
+        board.setTimeScaleModel(model);
+        int[] hx = header.getColumnXs(LocalDate.now());
+        int[] bx = board.getColumnXs(LocalDate.now());
+        assertArrayEquals(hx, bx, "header and board must align");
+    }
+}

--- a/src/test/java/com/materiel/client/view/planning/HitTestTopMostTileTest.java
+++ b/src/test/java/com/materiel/client/view/planning/HitTestTopMostTileTest.java
@@ -1,0 +1,35 @@
+package com.materiel.client.view.planning;
+
+import com.materiel.client.model.Intervention;
+import com.materiel.client.view.planning.layout.TimeScaleModel;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HitTestTopMostTileTest {
+    @Test
+    void pickReturnsTopMostTile() {
+        PlanningBoard board = new PlanningBoard();
+        board.setTimeScaleModel(new TimeScaleModel(100));
+        Intervention bottom = new Intervention();
+        bottom.setId(1L);
+        Intervention top = new Intervention();
+        top.setId(2L);
+        Rectangle r1 = new Rectangle(10, 10, 100, 50);
+        Rectangle r2 = new Rectangle(10, 10, 100, 50);
+        Map<Intervention, Rectangle> bounds = new LinkedHashMap<>();
+        bounds.put(bottom, r1);
+        bounds.put(top, r2); // top drawn last
+        board.setTileBounds(bounds);
+        Optional<Intervention> pick = board.pickTileAt(new Point(20, 20));
+        assertTrue(pick.isPresent());
+        assertEquals(top, pick.get());
+    }
+}

--- a/src/test/java/com/materiel/client/view/planning/layout/LaneLayoutTest.java
+++ b/src/test/java/com/materiel/client/view/planning/layout/LaneLayoutTest.java
@@ -1,0 +1,25 @@
+package com.materiel.client.view.planning.layout;
+
+import com.materiel.client.model.Intervention;
+import com.materiel.client.view.planning.UIConstants;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LaneLayoutTest {
+    @Test
+    void wrapOccursWhenWidthTooSmall() {
+        List<Intervention> interventions = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            interventions.add(new Intervention());
+        }
+        int rowUsableWidth = UIConstants.MIN_TILE_WIDTH * 2; // force wrap
+        Map<Intervention, LaneLayout.Lane> lanes = LaneLayout.computeLanes(interventions, rowUsableWidth);
+        LaneLayout.Lane lane = lanes.values().iterator().next();
+        assertTrue(lane.tracks > 1, "should wrap to multiple tracks");
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `TimeScaleModel` for pixel-accurate column calculation
- introduce `LaneLayout` with wrapping tracks and hit-tested tile bounds
- add color utilities and renderer for readable tiles; extend UI constants

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c11fa8e9b0833095ae6d570fb7ad9c