### PR TITLE
Align timeline header with grid and support lane wrapping

### DIFF
--- a/src/main/java/com/materiel/client/view/planning/PlanningBoard.java
+++ b/src/main/java/com/materiel/client/view/planning/PlanningBoard.java
@@ -135,11 +135,15 @@ public class PlanningBoard extends JPanel {
         tileBounds.clear();
         zOrder.clear();
         for (Map.Entry<Intervention, LaneLayout.Lane> e : lanes.entrySet()) {
-            Rectangle r = LaneLayout.computeTileBounds(e.getKey(), e.getValue(), scale);
-            int trackOffset = e.getValue().track * (UIConstants.ROW_BASE_HEIGHT + UIConstants.TRACK_V_GUTTER);
-            r.y += trackOffset;
-            tileBounds.put(e.getKey(), r);
-            zOrder.add(e.getKey());
+            Intervention in = e.getKey();
+            LaneLayout.Lane lane = e.getValue();
+            int x = scale.timeToX(in.getDateDebut());
+            int w = scale.timeToX(in.getDateFin()) - x;
+            int y = lane.track * (UIConstants.ROW_BASE_HEIGHT + UIConstants.TRACK_V_GUTTER);
+            int h = Math.max(UIConstants.MIN_TILE_HEIGHT, UIConstants.ROW_BASE_HEIGHT - 1);
+            Rectangle r = new Rectangle(x, y, w, h);
+            tileBounds.put(in, r);
+            zOrder.add(in);
         }
         rowLaneCounts.clear();
         rowLaneCounts.add(lanes.size());

--- a/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
+++ b/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
@@ -8,6 +8,8 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
 import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Locale;
 
 /** Header displaying day columns aligned with the planning grid. */
 public class TimelineHeader extends JComponent implements ChangeListener {
@@ -44,11 +46,30 @@ public class TimelineHeader extends JComponent implements ChangeListener {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         Graphics2D g2 = (Graphics2D) g.create();
+
+        int h = getHeight();
+        // Empty header cell over the resource column
+        g2.setColor(getBackground());
+        g2.fillRect(0, 0, UIConstants.LEFT_GUTTER_WIDTH, h);
         g2.setColor(Color.GRAY);
+        g2.drawRect(0, 0, UIConstants.LEFT_GUTTER_WIDTH, h - 1);
+
         int[] xs = model.getDayColumnXs(LocalDate.now());
-        for (int x : xs) {
-            g2.drawLine(x, 0, x, getHeight());
+        LocalDate d = LocalDate.now();
+        FontMetrics fm = g2.getFontMetrics();
+        for (int i = 0; i < xs.length; i++) {
+            int x = xs[i];
+            g2.drawLine(x, 0, x, h);
+            if (i + 1 < xs.length) {
+                int next = xs[i + 1];
+                String label = d.plusDays(i).getDayOfWeek()
+                        .getDisplayName(TextStyle.SHORT, Locale.getDefault());
+                int textX = x + (next - x - fm.stringWidth(label)) / 2;
+                int textY = (h + fm.getAscent()) / 2 - 2;
+                g2.drawString(label, textX, textY);
+            }
         }
+
         g2.dispose();
     }
 }

--- a/src/main/java/com/materiel/client/view/planning/layout/LaneLayout.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/LaneLayout.java
@@ -1,12 +1,14 @@
 package com.materiel.client.view.planning.layout;
 
-import java.awt.Rectangle;
+import com.materiel.client.model.Intervention;
+import com.materiel.client.view.ui.UIConstants;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.materiel.client.model.Intervention;
-import com.materiel.client.view.ui.UIConstants;
 
 /**
  * Layout helper computing lanes and tracks with wrapping when space is limited.
@@ -16,59 +18,67 @@ public final class LaneLayout {
     }
 
     /** Data describing lane position within tracks. */
-    public static class Lane {
-        public int index;
-        public int count;
-        public int track;
-        public int tracks;
+    public static final class Lane {
+        public final int index;   // column index within the track group
+        public final int count;   // number of columns in the track group
+        public final int track;   // vertical track index
+        public final int tracks;  // total number of tracks
+
+        public Lane(int index, int count, int track, int tracks) {
+            this.index = index;
+            this.count = count;
+            this.track = track;
+            this.tracks = tracks;
+        }
     }
 
     /**
-     * Assign lanes and wrap into vertical tracks when the available width is
-     * insufficient to display every lane at the minimum tile width.
+     * Compute lane assignment using an interval graph. Interventions are first
+     * assigned to lanes so that overlapping ones get different indices. The
+     * lanes are then wrapped into vertical tracks when the available width is
+     * insufficient to display all of them at the minimum tile width.
      *
-     * @param byResource    interventions for a resource
-     * @param rowUsableWidth width available for tiles excluding the left gutter
-     * @return lane metadata for each intervention preserving the iteration order
+     * @param interventionsForResource interventions for a resource
+     * @param rowUsableWidth           width available for tiles excluding the left gutter
+     * @return lane metadata for each intervention preserving iteration order
      */
-    public static Map<Intervention, Lane> computeLanes(List<Intervention> byResource, int rowUsableWidth) {
-        Map<Intervention, Lane> result = new LinkedHashMap<>();
-        int laneCount = byResource.size();
-        int tracks = (int) Math.ceil((laneCount * (double) UIConstants.MIN_TILE_WIDTH) / rowUsableWidth);
-        tracks = Math.max(tracks, 1);
+    public static Map<Intervention, Lane> computeLanes(
+            List<Intervention> interventionsForResource, int rowUsableWidth) {
+        List<Intervention> sorted = new ArrayList<>(interventionsForResource);
+        sorted.sort(Comparator.comparing(Intervention::getDateDebut));
 
-        int base = laneCount / tracks;
-        int extra = laneCount % tracks;
-        int laneIndex = 0;
-        for (int t = 0; t < tracks; t++) {
-            int count = base + (t < extra ? 1 : 0);
-            for (int i = 0; i < count; i++) {
-                Intervention in = byResource.get(laneIndex++);
-                Lane lane = new Lane();
-                lane.track = t;
-                lane.tracks = tracks;
-                lane.index = i;
-                lane.count = count;
-                result.put(in, lane);
+        // First pass: assign lane indices based on overlaps
+        List<LocalDateTime> laneEnd = new ArrayList<>();
+        Map<Intervention, Integer> laneIndex = new LinkedHashMap<>();
+        for (Intervention in : sorted) {
+            LocalDateTime start = in.getDateDebut();
+            LocalDateTime end = in.getDateFin();
+            int lane = 0;
+            while (lane < laneEnd.size() && laneEnd.get(lane).isAfter(start)) {
+                lane++;
             }
+            if (lane == laneEnd.size()) {
+                laneEnd.add(end);
+            } else {
+                laneEnd.set(lane, end);
+            }
+            laneIndex.put(in, lane);
+        }
+
+        int laneCount = laneEnd.size();
+        int tracks = Math.max(1,
+                (int) Math.ceil((laneCount * 1.0 * UIConstants.MIN_TILE_WIDTH) / rowUsableWidth));
+        int colsPerTrack = (int) Math.ceil(laneCount / (double) tracks);
+
+        Map<Intervention, Lane> result = new LinkedHashMap<>();
+        for (Map.Entry<Intervention, Integer> e : laneIndex.entrySet()) {
+            int lane = e.getValue();
+            int track = lane / colsPerTrack;
+            int index = lane % colsPerTrack;
+            int count = Math.min(colsPerTrack, laneCount - track * colsPerTrack);
+            result.put(e.getKey(), new Lane(index, count, track, tracks));
         }
         return result;
-    }
-
-    /**
-     * Compute pixel bounds of a tile inside its track. The returned rectangle is
-     * relative to the first track; callers must apply the track vertical offset.
-     */
-    public static Rectangle computeTileBounds(Intervention i, Lane lane, TimeGridModel scale) {
-        int y1 = scale.timeToY(i.getDateDebut());
-        int y2 = scale.timeToY(i.getDateFin());
-        int height = Math.max(UIConstants.ROW_BASE_HEIGHT, y2 - y1);
-
-        int[] xs = scale.getDayColumnXs(i.getDateDebut().toLocalDate());
-        int rowUsableWidth = xs[xs.length - 1] - scale.getLeftGutterWidth();
-        int laneWidth = lane.count == 0 ? rowUsableWidth : rowUsableWidth / lane.count;
-        int x = scale.getLeftGutterWidth() + lane.index * laneWidth;
-        return new Rectangle(x, y1, laneWidth, height);
     }
 
     /**
@@ -76,11 +86,9 @@ public final class LaneLayout {
      * width.
      */
     public static int computeRowHeight(int laneCount, int rowUsableWidth) {
-        if (laneCount <= 0) {
-            return UIConstants.ROW_BASE_HEIGHT;
-        }
-        int tracks = (int) Math.ceil((laneCount * (double) UIConstants.MIN_TILE_WIDTH) / rowUsableWidth);
-        tracks = Math.max(tracks, 1);
+        int tracks = Math.max(1,
+                (int) Math.ceil((laneCount * 1.0 * UIConstants.MIN_TILE_WIDTH) / rowUsableWidth));
         return UIConstants.ROW_BASE_HEIGHT * tracks + UIConstants.TRACK_V_GUTTER * (tracks - 1);
     }
 }
+

--- a/src/main/java/com/materiel/client/view/planning/layout/SimpleTimeGridModel.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/SimpleTimeGridModel.java
@@ -1,0 +1,64 @@
+package com.materiel.client.view.planning.layout;
+
+import com.materiel.client.view.ui.UIConstants;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.DayOfWeek;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Basic implementation of {@link TimeGridModel} using a uniform hour width.
+ * The week starts on Monday and spans seven days.
+ */
+public class SimpleTimeGridModel implements TimeGridModel {
+    private final int hourWidth;
+    private final int leftGutter;
+
+    public SimpleTimeGridModel(int hourWidth) {
+        this.hourWidth = hourWidth;
+        this.leftGutter = UIConstants.LEFT_GUTTER_WIDTH;
+    }
+
+    @Override
+    public int getLeftGutterWidth() {
+        return leftGutter;
+    }
+
+    @Override
+    public int[] getDayColumnXs(LocalDate weekStart) {
+        int dayWidth = hourWidth * 24;
+        int[] xs = new int[8];
+        xs[0] = leftGutter;
+        for (int i = 1; i <= 7; i++) {
+            xs[i] = leftGutter + i * dayWidth;
+        }
+        return xs;
+    }
+
+    @Override
+    public int timeToX(LocalDateTime t) {
+        int dayWidth = hourWidth * 24;
+        int dayIndex = t.getDayOfWeek().getValue() - 1; // Monday = 0
+        int minutes = t.getHour() * 60 + t.getMinute();
+        int offset = (int) Math.round(minutes * (hourWidth / 60.0));
+        return leftGutter + dayIndex * dayWidth + offset;
+    }
+
+    @Override
+    public LocalDateTime xToTime(int x) {
+        int dayWidth = hourWidth * 24;
+        int offset = Math.max(0, x - leftGutter);
+        int dayIndex = offset / dayWidth;
+        int withinDay = offset % dayWidth;
+        int minutes = (int) Math.round(withinDay * 60.0 / hourWidth);
+        int hour = minutes / 60;
+        int minute = minutes % 60;
+        LocalDate base = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .plusDays(dayIndex);
+        return LocalDateTime.of(base, LocalTime.of(hour, minute));
+    }
+}
+

--- a/src/main/java/com/materiel/client/view/planning/layout/TimeGridModel.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/TimeGridModel.java
@@ -2,49 +2,28 @@ package com.materiel.client.view.planning.layout;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
-import com.materiel.client.view.ui.UIConstants;
+/**
+ * Shared model to translate between time and pixel positions for the planning grid.
+ * All rounding of X positions happens inside this model.
+ */
+public interface TimeGridModel {
 
-/** Shared model to translate between time and pixel positions for the planning grid. */
-public class TimeGridModel {
-    private final int hourWidth;
-    private final int leftGutter;
-
-    public TimeGridModel(int hourWidth) {
-        this.hourWidth = hourWidth;
-        this.leftGutter = UIConstants.LEFT_GUTTER_WIDTH;
-    }
-
-    /** Width in pixels of the frozen left gutter. */
-    public int getLeftGutterWidth() {
-        return leftGutter;
-    }
+    /** @return width in pixels of the frozen left gutter. */
+    int getLeftGutterWidth();
 
     /**
-     * Compute x coordinates of hour boundaries for the given day.
-     * The provided monday is currently ignored but kept for future week layouts.
+     * Compute X coordinates of week day column boundaries including the left gutter offset.
+     *
+     * @param weekStart first day of the week (typically Monday)
+     * @return array of x positions for each day boundary
      */
-    public int[] getDayColumnXs(LocalDate monday) {
-        int[] xs = new int[25];
-        xs[0] = leftGutter;
-        for (int h = 1; h <= 24; h++) {
-            xs[h] = leftGutter + h * hourWidth;
-        }
-        return xs;
-    }
+    int[] getDayColumnXs(LocalDate weekStart);
 
-    /** Convert a time value to a y pixel coordinate. All rounding happens here. */
-    public int timeToY(LocalDateTime t) {
-        int minutes = t.getHour() * 60 + t.getMinute();
-        return Math.round(minutes * (UIConstants.ROW_BASE_HEIGHT / 60f));
-    }
+    /** Convert a time value to an X pixel coordinate. */
+    int timeToX(LocalDateTime t);
 
-    /** Convert a y pixel coordinate back to a time rounded to the nearest minute. */
-    public LocalDateTime yToTime(int y) {
-        int minutes = Math.round(y * 60f / UIConstants.ROW_BASE_HEIGHT);
-        int hour = minutes / 60;
-        int minute = minutes % 60;
-        return LocalDateTime.of(LocalDate.now(), LocalTime.of(hour, minute));
-    }
+    /** Convert an X pixel coordinate back to a time rounded to the nearest minute. */
+    LocalDateTime xToTime(int x);
 }
+

--- a/src/test/java/com/materiel/client/view/planning/HeaderAlignmentTest.java
+++ b/src/test/java/com/materiel/client/view/planning/HeaderAlignmentTest.java
@@ -1,5 +1,6 @@
 package com.materiel.client.view.planning;
 
+import com.materiel.client.view.planning.layout.SimpleTimeGridModel;
 import com.materiel.client.view.planning.layout.TimeGridModel;
 import org.junit.jupiter.api.Test;
 
@@ -8,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public class HeaderAlignmentTest {
     @Test
     void headerAndBoardShareSameModel() {
-        TimeGridModel model = new TimeGridModel(100);
+        TimeGridModel model = new SimpleTimeGridModel(100);
         TimelineHeader header = new TimelineHeader(model);
         PlanningBoard board = new PlanningBoard();
         board.setTimeGridModel(model);

--- a/src/test/java/com/materiel/client/view/planning/HitTestTopMostTileTest.java
+++ b/src/test/java/com/materiel/client/view/planning/HitTestTopMostTileTest.java
@@ -1,6 +1,7 @@
 package com.materiel.client.view.planning;
 
 import com.materiel.client.model.Intervention;
+import com.materiel.client.view.planning.layout.SimpleTimeGridModel;
 import com.materiel.client.view.planning.layout.TimeGridModel;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ public class HitTestTopMostTileTest {
     @Test
     void pickReturnsTopMostTile() {
         PlanningBoard board = new PlanningBoard();
-        board.setTimeGridModel(new TimeGridModel(100));
+        board.setTimeGridModel(new SimpleTimeGridModel(100));
         Intervention bottom = new Intervention();
         bottom.setId(1L);
         Intervention top = new Intervention();

--- a/src/test/java/com/materiel/client/view/planning/PlanningBoardTrackOffsetTest.java
+++ b/src/test/java/com/materiel/client/view/planning/PlanningBoardTrackOffsetTest.java
@@ -2,6 +2,7 @@ package com.materiel.client.view.planning;
 
 import com.materiel.client.model.Intervention;
 import com.materiel.client.view.planning.layout.LaneLayout;
+import com.materiel.client.view.planning.layout.SimpleTimeGridModel;
 import com.materiel.client.view.planning.layout.TimeGridModel;
 import com.materiel.client.view.ui.UIConstants;
 import org.junit.jupiter.api.Test;
@@ -19,17 +20,13 @@ public class PlanningBoardTrackOffsetTest {
     @Test
     void tilesAreOffsetByTrack() {
         PlanningBoard board = new PlanningBoard();
-        TimeGridModel scale = new TimeGridModel(100);
+        TimeGridModel scale = new SimpleTimeGridModel(100);
         Intervention in = new Intervention();
         in.setId(1L);
         in.setDateDebut(LocalDateTime.of(2024,1,1,0,0));
         in.setDateFin(LocalDateTime.of(2024,1,1,1,0));
 
-        LaneLayout.Lane lane = new LaneLayout.Lane();
-        lane.index = 0;
-        lane.count = 1;
-        lane.track = 1; // second track
-        lane.tracks = 2;
+        LaneLayout.Lane lane = new LaneLayout.Lane(0, 1, 1, 2);
 
         Map<Intervention, LaneLayout.Lane> lanes = new LinkedHashMap<>();
         lanes.put(in, lane);


### PR DESCRIPTION
## Summary
- Introduce TimeGridModel interface and a SimpleTimeGridModel implementation
- Add lane-wrapping logic with track support and row height calculation
- Align timeline header with grid columns and provide empty resource header cell
- Compute tile bounds via TimeGridModel in PlanningBoard

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c12f672f888330ac90ef0bcc6ac0e8