### PR TITLE
Align timeline header with grid and support lane wrapping

### DIFF
--- a/src/main/java/com/materiel/client/GestionMaterielApp.java
+++ b/src/main/java/com/materiel/client/GestionMaterielApp.java
@@ -16,6 +16,7 @@ import java.awt.*;
 public class GestionMaterielApp {
     
     public static void main(String[] args) {
+        System.out.println("FIX_WRAP_AND_ALIGN_APPLIED");
         // Configuration du Look & Feel FlatLaf
         try {
             UIManager.setLookAndFeel(new FlatLightLaf());

--- a/src/main/java/com/materiel/client/view/planning/PlanningBoard.java
+++ b/src/main/java/com/materiel/client/view/planning/PlanningBoard.java
@@ -12,7 +12,6 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -135,11 +134,12 @@ public class PlanningBoard extends JPanel {
         tileBounds.clear();
         zOrder.clear();
         for (Map.Entry<Intervention, LaneLayout.Lane> e : lanes.entrySet()) {
-            Rectangle r = LaneLayout.computeTileBounds(e.getKey(), e.getValue(), scale);
-            int trackOffset = e.getValue().track * (UIConstants.ROW_BASE_HEIGHT + UIConstants.TRACK_V_GUTTER);
-            r.y += trackOffset;
-            tileBounds.put(e.getKey(), r);
-            zOrder.add(e.getKey());
+            Intervention in = e.getKey();
+            LaneLayout.Lane lane = e.getValue();
+            Rectangle r = LaneLayout.computeTileBounds(
+                    in.getDateDebut(), in.getDateFin(), lane, scale, 0);
+            tileBounds.put(in, r);
+            zOrder.add(in);
         }
         rowLaneCounts.clear();
         rowLaneCounts.add(lanes.size());
@@ -164,9 +164,8 @@ public class PlanningBoard extends JPanel {
         if (scale == null) {
             return super.getPreferredSize();
         }
-        int[] xs = scale.getDayColumnXs(LocalDate.now());
-        int width = xs.length > 0 ? xs[xs.length - 1] : 0;
-        int rowUsableWidth = width - scale.getLeftGutterWidth();
+        int width = scale.getLeftGutterWidth() + scale.getContentWidth();
+        int rowUsableWidth = scale.getContentWidth();
         int height = 0;
         for (int laneCount : rowLaneCounts) {
             height += LaneLayout.computeRowHeight(laneCount, rowUsableWidth);

--- a/src/main/java/com/materiel/client/view/planning/PlanningPanel.java
+++ b/src/main/java/com/materiel/client/view/planning/PlanningPanel.java
@@ -613,7 +613,13 @@ public class PlanningPanel extends JPanel {
                     .collect(Collectors.toList());
             final int gutter = 2;
             final int available = DAY_COLUMN_WIDTH - 10;
-            Map<Intervention, LaneLayout.Lane> map = LaneLayout.computeLanes(ints, available);
+            Map<Intervention, LaneLayout.Lane> map = LaneLayout.computeLanes(
+                    ints,
+                    new LaneLayout.StartEnd<Intervention>() {
+                        @Override public LocalDateTime start(Intervention t) { return t.getDateDebut(); }
+                        @Override public LocalDateTime end(Intervention t) { return t.getDateFin(); }
+                    },
+                    available);
             int y = 0;
             for (InterventionCard c : interventionCards) {
                 LaneLayout.Lane lane = map.get(c.getIntervention());

--- a/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
+++ b/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
@@ -8,6 +8,8 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
 import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Locale;
 
 /** Header displaying day columns aligned with the planning grid. */
 public class TimelineHeader extends JComponent implements ChangeListener {
@@ -44,11 +46,30 @@ public class TimelineHeader extends JComponent implements ChangeListener {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         Graphics2D g2 = (Graphics2D) g.create();
+
+        int h = getHeight();
+        // Empty header cell over the resource column
+        g2.setColor(getBackground());
+        g2.fillRect(0, 0, UIConstants.LEFT_GUTTER_WIDTH, h);
         g2.setColor(Color.GRAY);
+        g2.drawRect(0, 0, UIConstants.LEFT_GUTTER_WIDTH, h - 1);
+
         int[] xs = model.getDayColumnXs(LocalDate.now());
-        for (int x : xs) {
-            g2.drawLine(x, 0, x, getHeight());
+        LocalDate d = LocalDate.now();
+        FontMetrics fm = g2.getFontMetrics();
+        for (int i = 0; i < xs.length; i++) {
+            int x = xs[i];
+            g2.drawLine(x, 0, x, h);
+            if (i + 1 < xs.length) {
+                int next = xs[i + 1];
+                String label = d.plusDays(i).getDayOfWeek()
+                        .getDisplayName(TextStyle.SHORT, Locale.getDefault());
+                int textX = x + (next - x - fm.stringWidth(label)) / 2;
+                int textY = (h + fm.getAscent()) / 2 - 2;
+                g2.drawString(label, textX, textY);
+            }
         }
+
         g2.dispose();
     }
 }

--- a/src/main/java/com/materiel/client/view/planning/layout/DefaultTimeGridModel.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/DefaultTimeGridModel.java
@@ -1,0 +1,66 @@
+package com.materiel.client.view.planning.layout;
+
+import java.time.*;
+
+import static com.materiel.client.view.ui.UIConstants.*;
+
+/**
+ * Default implementation of {@link TimeGridModel} converting between time and
+ * pixel positions for a weekly grid. All rounding logic is centralized here.
+ */
+public final class DefaultTimeGridModel implements TimeGridModel {
+    private final LocalDate weekStart;
+    private int pxPerHour;
+
+    public DefaultTimeGridModel(LocalDate weekStart, int pxPerHour) {
+        this.weekStart = weekStart;
+        this.pxPerHour = Math.max(8, pxPerHour);
+    }
+
+    /** Adjust horizontal zoom in pixels per hour. */
+    public void setPxPerHour(int v) {
+        this.pxPerHour = Math.max(8, v);
+    }
+
+    @Override
+    public int getLeftGutterWidth() {
+        return LEFT_GUTTER_WIDTH;
+    }
+
+    @Override
+    public int[] getDayColumnXs(LocalDate ws) {
+        LocalDate base = (ws != null) ? ws : weekStart;
+        int[] xs = new int[8];
+        xs[0] = LEFT_GUTTER_WIDTH;
+        int dayW = 24 * pxPerHour;
+        for (int d = 1; d <= 7; d++) {
+            xs[d] = LEFT_GUTTER_WIDTH + d * dayW;
+        }
+        return xs;
+    }
+
+    @Override
+    public int timeToX(LocalDateTime t) {
+        long days = Duration.between(weekStart.atStartOfDay(), t.withSecond(0).withNano(0)).toDays();
+        long minutes = Duration.between(t.toLocalDate().atStartOfDay(), t).toMinutes();
+        int x = LEFT_GUTTER_WIDTH + (int) days * (24 * pxPerHour)
+                + (int) ((minutes / 60.0) * pxPerHour);
+        return x;
+    }
+
+    @Override
+    public LocalDateTime xToTime(int x) {
+        int rel = Math.max(0, x - LEFT_GUTTER_WIDTH);
+        int dayW = 24 * pxPerHour;
+        int d = rel / dayW;
+        int rem = rel % dayW;
+        int h = rem / pxPerHour;
+        int m = (int) Math.round(((rem % pxPerHour) * 60.0) / pxPerHour);
+        return weekStart.plusDays(d).atTime(Math.min(23, h), Math.min(59, m));
+    }
+
+    @Override
+    public int getContentWidth() {
+        return 7 * 24 * pxPerHour;
+    }
+}

--- a/src/main/java/com/materiel/client/view/planning/layout/LaneLayout.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/LaneLayout.java
@@ -1,86 +1,91 @@
 package com.materiel.client.view.planning.layout;
 
 import java.awt.Rectangle;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.util.*;
 
-import com.materiel.client.model.Intervention;
-import com.materiel.client.view.ui.UIConstants;
+import static com.materiel.client.view.ui.UIConstants.*;
 
 /**
- * Layout helper computing lanes and tracks with wrapping when space is limited.
+ * Utility computing lane assignments and tile bounds with vertical wrapping
+ * when horizontal space is limited.
  */
 public final class LaneLayout {
-    private LaneLayout() {
+    private LaneLayout() {}
+
+    /** Metadata describing a lane within tracks. */
+    public static final class Lane {
+        public final int index;
+        public final int count;
+        public final int track;
+        public final int tracks;
+        public Lane(int index, int count, int track, int tracks) {
+            this.index = index;
+            this.count = count;
+            this.track = track;
+            this.tracks = tracks;
+        }
     }
 
-    /** Data describing lane position within tracks. */
-    public static class Lane {
-        public int index;
-        public int count;
-        public int track;
-        public int tracks;
+    /** Strategy interface to extract start/end from arbitrary items. */
+    public interface StartEnd<T> {
+        LocalDateTime start(T t);
+        LocalDateTime end(T t);
     }
 
     /**
-     * Assign lanes and wrap into vertical tracks when the available width is
-     * insufficient to display every lane at the minimum tile width.
-     *
-     * @param byResource    interventions for a resource
-     * @param rowUsableWidth width available for tiles excluding the left gutter
-     * @return lane metadata for each intervention preserving the iteration order
+     * Compute lane assignment for the given items. Items overlapping in time
+     * are placed in separate columns; when the total width would make columns
+     * narrower than {@link UIConstants#MIN_TILE_WIDTH}, lanes wrap vertically
+     * into multiple tracks.
      */
-    public static Map<Intervention, Lane> computeLanes(List<Intervention> byResource, int rowUsableWidth) {
-        Map<Intervention, Lane> result = new LinkedHashMap<>();
-        int laneCount = byResource.size();
-        int tracks = (int) Math.ceil((laneCount * (double) UIConstants.MIN_TILE_WIDTH) / rowUsableWidth);
-        tracks = Math.max(tracks, 1);
-
-        int base = laneCount / tracks;
-        int extra = laneCount % tracks;
-        int laneIndex = 0;
-        for (int t = 0; t < tracks; t++) {
-            int count = base + (t < extra ? 1 : 0);
-            for (int i = 0; i < count; i++) {
-                Intervention in = byResource.get(laneIndex++);
-                Lane lane = new Lane();
-                lane.track = t;
-                lane.tracks = tracks;
-                lane.index = i;
-                lane.count = count;
-                result.put(in, lane);
+    public static <T> Map<T, Lane> computeLanes(List<T> items, StartEnd<T> se, int rowUsableWidth) {
+        items.sort(Comparator.comparing(se::start));
+        List<T> open = new ArrayList<>();
+        Map<T, Integer> col = new HashMap<>();
+        int maxCols = 0;
+        for (T it : items) {
+            LocalDateTime s = se.start(it);
+            open.removeIf(o -> !se.end(o).isAfter(s));
+            boolean[] used = new boolean[open.size() + 1];
+            for (T o : open) {
+                used[col.get(o)] = true;
             }
+            int idx = 0;
+            while (idx < used.length && used[idx]) {
+                idx++;
+            }
+            col.put(it, idx);
+            open.add(it);
+            maxCols = Math.max(maxCols, idx + 1);
         }
-        return result;
+        int tracks = Math.max(1, (int) Math.ceil((maxCols * 1.0 * MIN_TILE_WIDTH) / Math.max(1, rowUsableWidth)));
+        Map<T, Lane> out = new LinkedHashMap<>();
+        int colsPerTrack = (int) Math.ceil(maxCols * 1.0 / tracks);
+        for (T it : items) {
+            int k = col.get(it);
+            int track = k % tracks;
+            int indexWithinTrack = k / tracks;
+            out.put(it, new Lane(indexWithinTrack, colsPerTrack, track, tracks));
+        }
+        return out;
     }
 
-    /**
-     * Compute pixel bounds of a tile inside its track. The returned rectangle is
-     * relative to the first track; callers must apply the track vertical offset.
-     */
-    public static Rectangle computeTileBounds(Intervention i, Lane lane, TimeGridModel scale) {
-        int y1 = scale.timeToY(i.getDateDebut());
-        int y2 = scale.timeToY(i.getDateFin());
-        int height = Math.max(UIConstants.ROW_BASE_HEIGHT, y2 - y1);
-
-        int[] xs = scale.getDayColumnXs(i.getDateDebut().toLocalDate());
-        int rowUsableWidth = xs[xs.length - 1] - scale.getLeftGutterWidth();
-        int laneWidth = lane.count == 0 ? rowUsableWidth : rowUsableWidth / lane.count;
-        int x = scale.getLeftGutterWidth() + lane.index * laneWidth;
-        return new Rectangle(x, y1, laneWidth, height);
-    }
-
-    /**
-     * Compute total row height depending on the number of lanes and available
-     * width.
-     */
+    /** Compute total row height for the given lane count and available width. */
     public static int computeRowHeight(int laneCount, int rowUsableWidth) {
-        if (laneCount <= 0) {
-            return UIConstants.ROW_BASE_HEIGHT;
-        }
-        int tracks = (int) Math.ceil((laneCount * (double) UIConstants.MIN_TILE_WIDTH) / rowUsableWidth);
-        tracks = Math.max(tracks, 1);
-        return UIConstants.ROW_BASE_HEIGHT * tracks + UIConstants.TRACK_V_GUTTER * (tracks - 1);
+        int tracks = Math.max(1, (int) Math.ceil((laneCount * 1.0 * MIN_TILE_WIDTH) / Math.max(1, rowUsableWidth)));
+        return ROW_BASE_HEIGHT * tracks + TRACK_V_GUTTER * (tracks - 1);
+    }
+
+    /** Compute pixel bounds of a tile inside its row and track. */
+    public static Rectangle computeTileBounds(LocalDateTime start, LocalDateTime end, Lane lane,
+                                             TimeGridModel grid, int rowY) {
+        int x1 = grid.timeToX(start);
+        int x2 = grid.timeToX(end);
+        int y = rowY + lane.track * (ROW_BASE_HEIGHT + TRACK_V_GUTTER);
+        int h = Math.max(MIN_TILE_HEIGHT, ROW_BASE_HEIGHT - 1);
+        int w = Math.max(1, Math.abs(x2 - x1));
+        int x = Math.min(x1, x2);
+        return new Rectangle(x, y, w, h);
     }
 }

--- a/src/main/java/com/materiel/client/view/planning/layout/TimeGridModel.java
+++ b/src/main/java/com/materiel/client/view/planning/layout/TimeGridModel.java
@@ -2,49 +2,31 @@ package com.materiel.client.view.planning.layout;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
-import com.materiel.client.view.ui.UIConstants;
+/**
+ * Shared model to translate between time and pixel positions for the planning grid.
+ * All rounding of X positions happens inside this model.
+ */
+public interface TimeGridModel {
 
-/** Shared model to translate between time and pixel positions for the planning grid. */
-public class TimeGridModel {
-    private final int hourWidth;
-    private final int leftGutter;
-
-    public TimeGridModel(int hourWidth) {
-        this.hourWidth = hourWidth;
-        this.leftGutter = UIConstants.LEFT_GUTTER_WIDTH;
-    }
-
-    /** Width in pixels of the frozen left gutter. */
-    public int getLeftGutterWidth() {
-        return leftGutter;
-    }
+    /** @return width in pixels of the frozen left gutter. */
+    int getLeftGutterWidth();
 
     /**
-     * Compute x coordinates of hour boundaries for the given day.
-     * The provided monday is currently ignored but kept for future week layouts.
+     * Compute X coordinates of week day column boundaries including the left gutter offset.
+     *
+     * @param weekStart first day of the week (typically Monday)
+     * @return array of x positions for each day boundary
      */
-    public int[] getDayColumnXs(LocalDate monday) {
-        int[] xs = new int[25];
-        xs[0] = leftGutter;
-        for (int h = 1; h <= 24; h++) {
-            xs[h] = leftGutter + h * hourWidth;
-        }
-        return xs;
-    }
+    int[] getDayColumnXs(LocalDate weekStart);
 
-    /** Convert a time value to a y pixel coordinate. All rounding happens here. */
-    public int timeToY(LocalDateTime t) {
-        int minutes = t.getHour() * 60 + t.getMinute();
-        return Math.round(minutes * (UIConstants.ROW_BASE_HEIGHT / 60f));
-    }
+    /** Convert a time value to an X pixel coordinate. */
+    int timeToX(LocalDateTime t);
 
-    /** Convert a y pixel coordinate back to a time rounded to the nearest minute. */
-    public LocalDateTime yToTime(int y) {
-        int minutes = Math.round(y * 60f / UIConstants.ROW_BASE_HEIGHT);
-        int hour = minutes / 60;
-        int minute = minutes % 60;
-        return LocalDateTime.of(LocalDate.now(), LocalTime.of(hour, minute));
-    }
+    /** Convert an X pixel coordinate back to a time rounded to the nearest minute. */
+    LocalDateTime xToTime(int x);
+
+    /** @return usable content width excluding the left gutter. */
+    int getContentWidth();
 }
+

--- a/src/main/java/com/materiel/client/view/ui/UIConstants.java
+++ b/src/main/java/com/materiel/client/view/ui/UIConstants.java
@@ -4,21 +4,14 @@ package com.materiel.client.view.ui;
 public final class UIConstants {
     private UIConstants() {}
 
-    // Layout général
-    public static final int LEFT_GUTTER_WIDTH = 180;
-    public static final int ROW_BASE_HEIGHT = 88;
-    public static final int TRACK_V_GUTTER = 6;
+    // Mise en page
+    public static final int LEFT_GUTTER_WIDTH = 180; // colonne "Ressources"
+    public static final int ROW_BASE_HEIGHT = 88;    // hauteur d'un track
+    public static final int TRACK_V_GUTTER = 6;      // espace entre tracks
 
     // Tuiles
-    public static final int MIN_TILE_WIDTH = 120;
+    public static final int MIN_TILE_WIDTH = 120;    // largeur mini lisible
     public static final int MIN_TILE_HEIGHT = 20;
     public static final int TILE_PADDING = 6;
     public static final int TILE_BORDER = 1;
-    public static final int TILE_RADIUS = 8;
-
-    // Grille/temps
-    public static final int MIN_TIME_SLICE_MINUTES = 15;
-
-    // Compatibilité anciennes constantes
-    public static final int TILE_BORDER_WIDTH = TILE_BORDER;
 }

--- a/src/test/java/com/materiel/client/view/planning/HeaderAlignmentTest.java
+++ b/src/test/java/com/materiel/client/view/planning/HeaderAlignmentTest.java
@@ -1,6 +1,9 @@
 package com.materiel.client.view.planning;
 
+import com.materiel.client.view.planning.layout.DefaultTimeGridModel;
 import com.materiel.client.view.planning.layout.TimeGridModel;
+
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -8,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public class HeaderAlignmentTest {
     @Test
     void headerAndBoardShareSameModel() {
-        TimeGridModel model = new TimeGridModel(100);
+        TimeGridModel model = new DefaultTimeGridModel(LocalDate.now(), 100);
         TimelineHeader header = new TimelineHeader(model);
         PlanningBoard board = new PlanningBoard();
         board.setTimeGridModel(model);

--- a/src/test/java/com/materiel/client/view/planning/HitTestTopMostTileTest.java
+++ b/src/test/java/com/materiel/client/view/planning/HitTestTopMostTileTest.java
@@ -1,6 +1,7 @@
 package com.materiel.client.view.planning;
 
 import com.materiel.client.model.Intervention;
+import com.materiel.client.view.planning.layout.DefaultTimeGridModel;
 import com.materiel.client.view.planning.layout.TimeGridModel;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,7 @@ import java.awt.Rectangle;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,7 +19,7 @@ public class HitTestTopMostTileTest {
     @Test
     void pickReturnsTopMostTile() {
         PlanningBoard board = new PlanningBoard();
-        board.setTimeGridModel(new TimeGridModel(100));
+        board.setTimeGridModel(new DefaultTimeGridModel(LocalDate.now(), 100));
         Intervention bottom = new Intervention();
         bottom.setId(1L);
         Intervention top = new Intervention();

--- a/src/test/java/com/materiel/client/view/planning/PlanningBoardTrackOffsetTest.java
+++ b/src/test/java/com/materiel/client/view/planning/PlanningBoardTrackOffsetTest.java
@@ -2,6 +2,7 @@ package com.materiel.client.view.planning;
 
 import com.materiel.client.model.Intervention;
 import com.materiel.client.view.planning.layout.LaneLayout;
+import com.materiel.client.view.planning.layout.DefaultTimeGridModel;
 import com.materiel.client.view.planning.layout.TimeGridModel;
 import com.materiel.client.view.ui.UIConstants;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.awt.Point;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -19,17 +21,13 @@ public class PlanningBoardTrackOffsetTest {
     @Test
     void tilesAreOffsetByTrack() {
         PlanningBoard board = new PlanningBoard();
-        TimeGridModel scale = new TimeGridModel(100);
+        TimeGridModel scale = new DefaultTimeGridModel(LocalDate.now(), 100);
         Intervention in = new Intervention();
         in.setId(1L);
         in.setDateDebut(LocalDateTime.of(2024,1,1,0,0));
         in.setDateFin(LocalDateTime.of(2024,1,1,1,0));
 
-        LaneLayout.Lane lane = new LaneLayout.Lane();
-        lane.index = 0;
-        lane.count = 1;
-        lane.track = 1; // second track
-        lane.tracks = 2;
+        LaneLayout.Lane lane = new LaneLayout.Lane(0, 1, 1, 2);
 
         Map<Intervention, LaneLayout.Lane> lanes = new LinkedHashMap<>();
         lanes.put(in, lane);

--- a/src/test/java/com/materiel/client/view/planning/layout/HeaderAlignmentSmokeTest.java
+++ b/src/test/java/com/materiel/client/view/planning/layout/HeaderAlignmentSmokeTest.java
@@ -1,0 +1,15 @@
+package com.materiel.client.view.planning.layout;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HeaderAlignmentSmokeTest {
+  @Test void gridAndHeaderShareModel() {
+    TimeGridModel model = new DefaultTimeGridModel(java.time.LocalDate.now(), 100);
+    assertTrue(model.getLeftGutterWidth() > 0, "Left gutter must be > 0");
+    int[] xs = model.getDayColumnXs(java.time.LocalDate.now());
+    assertNotNull(xs);
+    assertTrue(xs.length > 1, "At least two X boundaries expected");
+  }
+}

--- a/src/test/java/com/materiel/client/view/planning/layout/LaneLayoutTest.java
+++ b/src/test/java/com/materiel/client/view/planning/layout/LaneLayoutTest.java
@@ -4,6 +4,7 @@ import com.materiel.client.model.Intervention;
 import com.materiel.client.view.ui.UIConstants;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -15,11 +16,21 @@ public class LaneLayoutTest {
     @Test
     void wrapOccursWhenWidthTooSmall() {
         List<Intervention> interventions = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
         for (int i = 0; i < 5; i++) {
-            interventions.add(new Intervention());
+            Intervention in = new Intervention();
+            in.setDateDebut(now);
+            in.setDateFin(now.plusHours(1));
+            interventions.add(in);
         }
         int rowUsableWidth = UIConstants.MIN_TILE_WIDTH * 2; // force wrap
-        Map<Intervention, LaneLayout.Lane> lanes = LaneLayout.computeLanes(interventions, rowUsableWidth);
+        Map<Intervention, LaneLayout.Lane> lanes = LaneLayout.computeLanes(
+                interventions,
+                new LaneLayout.StartEnd<Intervention>() {
+                    @Override public LocalDateTime start(Intervention t) { return t.getDateDebut(); }
+                    @Override public LocalDateTime end(Intervention t) { return t.getDateFin(); }
+                },
+                rowUsableWidth);
         LaneLayout.Lane lane = lanes.values().iterator().next();
         assertTrue(lane.tracks > 1, "should wrap to multiple tracks");
     }

--- a/src/test/java/com/materiel/client/view/planning/layout/RowWrapLayoutSmokeTest.java
+++ b/src/test/java/com/materiel/client/view/planning/layout/RowWrapLayoutSmokeTest.java
@@ -1,0 +1,14 @@
+package com.materiel.client.view.planning.layout;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RowWrapLayoutSmokeTest {
+  @Test void computeRowHeightIncreasesWithLanes() {
+    int w = 300;
+    int h1 = LaneLayout.computeRowHeight(1, w);
+    int h5 = LaneLayout.computeRowHeight(5, w);
+    assertTrue(h5 >= h1, "Row height must grow with more lanes when width limited");
+  }
+}


### PR DESCRIPTION
## Summary
- Centralize Swing layout constants for gutter, tile size and padding
- Share `DefaultTimeGridModel` across header and board with pixel-aligned day columns
- Add `LaneLayout` to wrap overlapping interventions into vertical tracks and compute dynamic row heights

## Testing
- `mvn -q -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c12f672f888330ac90ef0bcc6ac0e8