### PR TITLE
Handle overlapping planning tiles with shared time grid

### DIFF
--- a/src/main/java/com/materiel/client/util/UIConstants.java
+++ b/src/main/java/com/materiel/client/util/UIConstants.java
@@ -1,0 +1,22 @@
+package com.materiel.client.util;
+
+/**
+ * Constantes UI partagées pour le planning.
+ */
+public final class UIConstants {
+    private UIConstants() {}
+
+    // Gouttière gauche "Ressources"
+    public static final int LEFT_GUTTER_WIDTH = 180;
+
+    // Hauteur d'un "track" (bloc vertical de tuiles)
+    public static final int ROW_BASE_HEIGHT = 88;
+    public static final int TRACK_V_GUTTER = 6; // espace entre tracks
+
+    // Tuiles
+    public static final int MIN_TILE_WIDTH = 120;
+    public static final int MIN_TILE_HEIGHT = 20;
+    public static final int TILE_PADDING = 6;
+    public static final int TILE_BORDER = 1;
+}
+

--- a/src/main/java/com/materiel/client/view/planning/DefaultTimeGridModel.java
+++ b/src/main/java/com/materiel/client/view/planning/DefaultTimeGridModel.java
@@ -1,0 +1,57 @@
+package com.materiel.client.view.planning;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.materiel.client.util.UIConstants;
+
+/** Implémentation simple : 1 jour = 24h * pxPerHour. */
+public final class DefaultTimeGridModel implements TimeGridModel {
+    private LocalDate weekStart;
+    private int pxPerHour;
+
+    public DefaultTimeGridModel(LocalDate weekStart, int pxPerHour) {
+        this.weekStart = weekStart.with(DayOfWeek.MONDAY);
+        this.pxPerHour = Math.max(8, pxPerHour);
+    }
+
+    public void setWeek(LocalDate ws) { this.weekStart = ws.with(DayOfWeek.MONDAY); }
+
+    public void setPxPerHour(int pxHour) { this.pxPerHour = Math.max(8, pxHour); }
+
+    @Override public int getLeftGutterWidth() { return UIConstants.LEFT_GUTTER_WIDTH; }
+
+    @Override public int[] getDayColumnXs(LocalDate ws) {
+        LocalDate base = (ws != null) ? ws.with(DayOfWeek.MONDAY) : weekStart;
+        int[] xs = new int[8];
+        xs[0] = UIConstants.LEFT_GUTTER_WIDTH;
+        int dayW = 24 * pxPerHour;
+        for (int d = 1; d <= 7; d++) xs[d] = UIConstants.LEFT_GUTTER_WIDTH + d * dayW;
+        return xs;
+    }
+
+    @Override public int timeToX(LocalDateTime t) {
+        long days = Duration.between(weekStart.atStartOfDay(), t.withSecond(0).withNano(0)).toDays();
+        int minutesInDay = t.getHour() * 60 + t.getMinute();
+        return UIConstants.LEFT_GUTTER_WIDTH + (int) days * (24 * pxPerHour)
+                + Math.round((minutesInDay / 60f) * pxPerHour);
+    }
+
+    @Override public LocalDateTime xToTime(int x) {
+        int rel = Math.max(0, x - UIConstants.LEFT_GUTTER_WIDTH);
+        int dayW = 24 * pxPerHour;
+        int d = rel / dayW;
+        int rem = rel % dayW;
+        int h = rem / pxPerHour;
+        int m = Math.round(((rem % pxPerHour) * 60f) / pxPerHour);
+        LocalDate day = weekStart.plusDays(Math.min(6, Math.max(0, d)));
+        return day.atTime(Math.min(23, h), Math.min(59, m));
+    }
+
+    @Override public int getContentWidth() {
+        return 7 * 24 * pxPerHour;
+    }
+}
+

--- a/src/main/java/com/materiel/client/view/planning/LaneLayout.java
+++ b/src/main/java/com/materiel/client/view/planning/LaneLayout.java
@@ -1,0 +1,102 @@
+package com.materiel.client.view.planning;
+
+import static com.materiel.client.util.UIConstants.*;
+
+import java.awt.Rectangle;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Outils de calcul des "lanes" : colonnes et pistes verticales pour
+ * l'agencement des tuiles de planning.
+ */
+public final class LaneLayout {
+    private LaneLayout() {}
+
+    /** Informations d'une tuile dans une ligne. */
+    public static final class Lane {
+        public final int index;   // index dans le track (0..count-1)
+        public final int count;   // nb de colonnes dans le track
+        public final int track;   // piste verticale (0..tracks-1)
+        public final int tracks;  // nb total de pistes de la ligne
+
+        public Lane(int index, int count, int track, int tracks) {
+            this.index = index; this.count = count; this.track = track; this.tracks = tracks;
+        }
+    }
+
+    /** Interface bi-fonctionnelle pour extraire start/end. */
+    public interface StartEnd<T> { LocalDateTime start(T t); LocalDateTime end(T t); }
+
+    /** Surcharge pratique (évite l'erreur "target type must be a functional interface"). */
+    public static <T> Map<T, Lane> computeLanes(List<T> items,
+            Function<T, LocalDateTime> startFn,
+            Function<T, LocalDateTime> endFn,
+            int rowUsableWidth) {
+        return computeLanes(items, new StartEnd<>() {
+            @Override public LocalDateTime start(T t) { return startFn.apply(t); }
+            @Override public LocalDateTime end(T t) { return endFn.apply(t); }
+        }, rowUsableWidth);
+    }
+
+    /** Calcule colonnes + tracks à partir d'une liste d'items chevauchants. */
+    public static <T> Map<T, Lane> computeLanes(List<T> items, StartEnd<T> se, int rowUsableWidth) {
+        if (items == null || items.isEmpty()) return Collections.emptyMap();
+        items.sort(Comparator.comparing(se::start));
+
+        // Sweep-line : 1ère colonne libre
+        List<T> open = new ArrayList<>();
+        Map<T,Integer> col = new LinkedHashMap<>();
+        int maxCols = 0;
+        for (T it : items) {
+            LocalDateTime s = se.start(it);
+            open.removeIf(o -> !se.end(o).isAfter(s));
+            boolean[] used = new boolean[open.size()+1];
+            for (T o : open) used[col.get(o)] = true;
+            int idx = 0; while (idx < used.length && used[idx]) idx++;
+            col.put(it, idx);
+            open.add(it);
+            maxCols = Math.max(maxCols, idx+1);
+        }
+
+        int tracks = Math.max(1,
+                (int) Math.ceil((maxCols * 1.0 * MIN_TILE_WIDTH) / Math.max(1, rowUsableWidth)));
+        int colsPerTrack = (int) Math.ceil(maxCols * 1.0 / tracks);
+
+        Map<T, Lane> out = new LinkedHashMap<>();
+        for (T it : items) {
+            int k = col.get(it);
+            int track = k % tracks;
+            int indexWithinTrack = k / tracks;
+            out.put(it, new Lane(indexWithinTrack, colsPerTrack, track, tracks));
+        }
+        return out;
+    }
+
+    /** Hauteur réelle d'une ligne selon le nombre de colonnes nécessaires. */
+    public static int computeRowHeight(int laneCount, int rowUsableWidth) {
+        int tracks = Math.max(1,
+                (int) Math.ceil((laneCount * 1.0 * MIN_TILE_WIDTH) / Math.max(1, rowUsableWidth)));
+        return ROW_BASE_HEIGHT * tracks + TRACK_V_GUTTER * (tracks - 1);
+    }
+
+    /** Rectangle d'une tuile (dans le track). */
+    public static Rectangle computeTileBounds(
+            LocalDateTime start, LocalDateTime end,
+            Lane lane, TimeGridModel grid, int rowY) {
+        int x1 = grid.timeToX(start);
+        int x2 = grid.timeToX(end);
+        int y = rowY + lane.track * (ROW_BASE_HEIGHT + TRACK_V_GUTTER);
+        int h = Math.max(MIN_TILE_HEIGHT, ROW_BASE_HEIGHT - 1);
+        int w = Math.max(1, Math.abs(x2 - x1));
+        int x = Math.min(x1, x2);
+        return new Rectangle(x, y, w, h);
+    }
+}
+

--- a/src/main/java/com/materiel/client/view/planning/TimeGridModel.java
+++ b/src/main/java/com/materiel/client/view/planning/TimeGridModel.java
@@ -1,0 +1,24 @@
+package com.materiel.client.view.planning;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/** Modèle de grille temporelle partagé (header + grille). */
+public interface TimeGridModel {
+    int getLeftGutterWidth();
+
+    /**
+     * Renvoie 8 bornes X pour 7 jours (inclut la gouttière gauche).
+     */
+    int[] getDayColumnXs(LocalDate weekStart);
+
+    int timeToX(LocalDateTime t);
+
+    LocalDateTime xToTime(int x);
+
+    /**
+     * Largeur totale des 7 jours (sans la gouttière).
+     */
+    int getContentWidth();
+}
+

--- a/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
+++ b/src/main/java/com/materiel/client/view/planning/TimelineHeader.java
@@ -15,8 +15,7 @@ import java.util.Locale;
 
 import javax.swing.JComponent;
 
-import com.materiel.client.view.planning.layout.TimeGridModel;
-import com.materiel.client.view.ui.UIConstants;
+import com.materiel.client.util.UIConstants;
 
 /** Header displaying day columns aligned with the planning grid. */
 public final class TimelineHeader extends JComponent {


### PR DESCRIPTION
## Summary
- expose planning UI constants in util package
- add shared TimeGridModel, DefaultTimeGridModel and LaneLayout helpers
- refactor PlanningBoard to wrap overlapping tiles and log activation
- align TimelineHeader columns using shared grid

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1737f55c48330aa0d62e1f26278fe