### PR TITLE
Ajout des modèles et services mock pour la chaîne documentaire

### DIFF
--- a/src/main/java/com/materiel/client/mock/DeliveryNoteServiceMock.java
+++ b/src/main/java/com/materiel/client/mock/DeliveryNoteServiceMock.java
@@ -1,0 +1,84 @@
+package com.materiel.client.mock;
+
+import com.materiel.client.model.*;
+import com.materiel.client.service.DeliveryNoteService;
+import com.materiel.client.service.SequenceService;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.*;
+
+/**
+ * Implémentation mock pour les bons de livraison.
+ */
+public class DeliveryNoteServiceMock implements DeliveryNoteService {
+    private final JsonStore<DeliveryNote> store;
+    private final SequenceService sequenceService;
+    private final List<DeliveryNote> cache;
+
+    public DeliveryNoteServiceMock(Path dataDir, SequenceService sequenceService) {
+        this.store = new JsonStore<>(dataDir.resolve("delivery_notes.json"), DeliveryNote[].class);
+        this.sequenceService = sequenceService;
+        this.cache = store.load();
+    }
+
+    @Override
+    public List<DeliveryNote> list() { return new ArrayList<>(cache); }
+
+    @Override
+    public DeliveryNote get(UUID id) { return cache.stream().filter(o -> o.getId().equals(id)).findFirst().orElse(null); }
+
+    @Override
+    public DeliveryNote create(DeliveryNote note) {
+        if (note.getId() == null) note.setId(UUID.randomUUID());
+        if (note.getNumber() == null) note.setNumber(generateNumber(note.getDate()));
+        note.recalcTotals();
+        cache.add(note);
+        store.save(cache);
+        return note;
+    }
+
+    @Override
+    public DeliveryNote update(DeliveryNote note) {
+        delete(note.getId());
+        note.recalcTotals();
+        cache.add(note);
+        store.save(cache);
+        return note;
+    }
+
+    @Override
+    public void delete(UUID id) {
+        cache.removeIf(o -> o.getId().equals(id));
+        store.save(cache);
+    }
+
+    @Override
+    public DeliveryNote transition(UUID id, DocumentStatus newStatus) {
+        DeliveryNote bl = get(id);
+        if (bl != null) {
+            bl.setStatus(newStatus);
+            update(bl);
+        }
+        return bl;
+    }
+
+    @Override
+    public String generateNumber(LocalDate date) {
+        return sequenceService.nextNumber(DocumentType.DELIVERY_NOTE, date);
+    }
+
+    @Override
+    public DeliveryNote fromOrder(Order order, List<UUID> interventionIds) {
+        DeliveryNote bl = new DeliveryNote();
+        bl.setOrderId(order.getId());
+        bl.setCustomerId(order.getCustomerId());
+        bl.setCustomerName(order.getCustomerName());
+        bl.setLines(new ArrayList<>(order.getLines()));
+        bl.setInterventionIds(new ArrayList<>(interventionIds));
+        bl.setDate(LocalDate.now());
+        bl.recalcTotals();
+        bl.setStatus(DocumentStatus.DRAFT);
+        return create(bl);
+    }
+}

--- a/src/main/java/com/materiel/client/mock/InvoiceServiceMock.java
+++ b/src/main/java/com/materiel/client/mock/InvoiceServiceMock.java
@@ -1,0 +1,104 @@
+package com.materiel.client.mock;
+
+import com.materiel.client.model.*;
+import com.materiel.client.service.InvoiceService;
+import com.materiel.client.service.SequenceService;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.*;
+
+/**
+ * Implémentation mock des factures.
+ */
+public class InvoiceServiceMock implements InvoiceService {
+    private final JsonStore<Invoice> store;
+    private final SequenceService sequenceService;
+    private final List<Invoice> cache;
+
+    public InvoiceServiceMock(Path dataDir, SequenceService sequenceService) {
+        this.store = new JsonStore<>(dataDir.resolve("invoices.json"), Invoice[].class);
+        this.sequenceService = sequenceService;
+        this.cache = store.load();
+    }
+
+    @Override
+    public List<Invoice> list() { return new ArrayList<>(cache); }
+
+    @Override
+    public Invoice get(UUID id) { return cache.stream().filter(o -> o.getId().equals(id)).findFirst().orElse(null); }
+
+    @Override
+    public Invoice create(Invoice invoice) {
+        if (invoice.getId() == null) invoice.setId(UUID.randomUUID());
+        if (invoice.getNumber() == null) invoice.setNumber(generateNumber(invoice.getDate()));
+        invoice.recalcTotals();
+        cache.add(invoice);
+        store.save(cache);
+        return invoice;
+    }
+
+    @Override
+    public Invoice update(Invoice invoice) {
+        delete(invoice.getId());
+        invoice.recalcTotals();
+        cache.add(invoice);
+        store.save(cache);
+        return invoice;
+    }
+
+    @Override
+    public void delete(UUID id) {
+        cache.removeIf(o -> o.getId().equals(id));
+        store.save(cache);
+    }
+
+    @Override
+    public Invoice transition(UUID id, DocumentStatus newStatus) {
+        Invoice inv = get(id);
+        if (inv != null) {
+            inv.setStatus(newStatus);
+            update(inv);
+        }
+        return inv;
+    }
+
+    @Override
+    public String generateNumber(LocalDate date) {
+        return sequenceService.nextNumber(DocumentType.INVOICE, date);
+    }
+
+    @Override
+    public Invoice fromQuote(Quote quote) {
+        Invoice invoice = new Invoice();
+        invoice.setQuoteId(quote.getId());
+        invoice.setCustomerId(quote.getCustomerId());
+        invoice.setCustomerName(quote.getCustomerName());
+        invoice.setLines(new ArrayList<>(quote.getLines()));
+        invoice.setDate(LocalDate.now());
+        invoice.recalcTotals();
+        invoice.setStatus(DocumentStatus.DRAFT);
+        return create(invoice);
+    }
+
+    @Override
+    public Invoice fromDeliveryNotes(List<DeliveryNote> notes) {
+        Invoice invoice = new Invoice();
+        if (!notes.isEmpty()) {
+            DeliveryNote first = notes.get(0);
+            invoice.setCustomerId(first.getCustomerId());
+            invoice.setCustomerName(first.getCustomerName());
+        }
+        invoice.setDeliveryNoteIds(new ArrayList<>());
+        List<DocumentLine> lines = new ArrayList<>();
+        for (DeliveryNote note : notes) {
+            invoice.getDeliveryNoteIds().add(note.getId());
+            lines.addAll(note.getLines());
+        }
+        invoice.setLines(lines);
+        invoice.setDate(LocalDate.now());
+        invoice.recalcTotals();
+        invoice.setStatus(DocumentStatus.DRAFT);
+        return create(invoice);
+    }
+}

--- a/src/main/java/com/materiel/client/mock/JsonStore.java
+++ b/src/main/java/com/materiel/client/mock/JsonStore.java
@@ -1,0 +1,48 @@
+package com.materiel.client.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Stockage générique JSON d'une liste d'objets.
+ */
+public class JsonStore<T> {
+    private final ObjectMapper mapper;
+    private final Path file;
+    private final Class<T[]> arrayType;
+
+    public JsonStore(Path file, Class<T[]> arrayType) {
+        this.file = file;
+        this.arrayType = arrayType;
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+    }
+
+    public synchronized List<T> load() {
+        try {
+            if (Files.notExists(file)) {
+                return new ArrayList<>();
+            }
+            T[] arr = mapper.readValue(file.toFile(), arrayType);
+            return new ArrayList<>(Arrays.asList(arr));
+        } catch (IOException e) {
+            throw new RuntimeException("Erreur de lecture JSON", e);
+        }
+    }
+
+    public synchronized void save(List<T> data) {
+        try {
+            Files.createDirectories(file.getParent());
+            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), data);
+        } catch (IOException e) {
+            throw new RuntimeException("Erreur d'écriture JSON", e);
+        }
+    }
+}

--- a/src/main/java/com/materiel/client/mock/OrderServiceMock.java
+++ b/src/main/java/com/materiel/client/mock/OrderServiceMock.java
@@ -1,0 +1,87 @@
+package com.materiel.client.mock;
+
+import com.materiel.client.model.*;
+import com.materiel.client.service.OrderService;
+import java.nio.file.Path;
+import com.materiel.client.service.SequenceService;
+
+import java.time.LocalDate;
+import java.util.*;
+
+/**
+ * Implémentation mock du service de commandes avec persistance JSON.
+ */
+public class OrderServiceMock implements OrderService {
+    private final JsonStore<Order> store;
+    private final SequenceService sequenceService;
+    private final List<Order> cache;
+
+    public OrderServiceMock(Path dataDir, SequenceService sequenceService) {
+        this.store = new JsonStore<>(dataDir.resolve("orders.json"), Order[].class);
+        this.sequenceService = sequenceService;
+        this.cache = store.load();
+    }
+
+    @Override
+    public List<Order> list() { return new ArrayList<>(cache); }
+
+    @Override
+    public Order get(UUID id) { return cache.stream().filter(o -> o.getId().equals(id)).findFirst().orElse(null); }
+
+    @Override
+    public Order create(Order order) {
+        if (order.getId() == null) order.setId(UUID.randomUUID());
+        if (order.getNumber() == null) order.setNumber(generateNumber(order.getDate()));
+        order.recalcTotals();
+        cache.add(order);
+        store.save(cache);
+        return order;
+    }
+
+    @Override
+    public Order update(Order order) {
+        delete(order.getId());
+        order.recalcTotals();
+        cache.add(order);
+        store.save(cache);
+        return order;
+    }
+
+    @Override
+    public void delete(UUID id) {
+        cache.removeIf(o -> o.getId().equals(id));
+        store.save(cache);
+    }
+
+    @Override
+    public Order transition(UUID id, DocumentStatus newStatus) {
+        Order o = get(id);
+        if (o != null) {
+            o.setStatus(newStatus);
+            update(o);
+        }
+        return o;
+    }
+
+    @Override
+    public String generateNumber(LocalDate date) {
+        return sequenceService.nextNumber(DocumentType.ORDER, date);
+    }
+
+    @Override
+    public Order fromQuote(Quote quote) {
+        Order order = new Order();
+        order.setQuoteId(quote.getId());
+        order.setCustomerId(quote.getCustomerId());
+        order.setCustomerName(quote.getCustomerName());
+        order.setLines(new ArrayList<>(quote.getLines()));
+        order.setDate(LocalDate.now());
+        order.recalcTotals();
+        if (DocumentStatus.ACCEPTED.equals(quote.getStatus())) {
+            order.setStatus(DocumentStatus.CONFIRMED);
+        } else {
+            order.setStatus(DocumentStatus.DRAFT);
+        }
+        return create(order);
+    }
+}

--- a/src/main/java/com/materiel/client/mock/SequenceServiceMock.java
+++ b/src/main/java/com/materiel/client/mock/SequenceServiceMock.java
@@ -1,0 +1,67 @@
+package com.materiel.client.mock;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.materiel.client.model.DocumentType;
+import com.materiel.client.service.SequenceService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implémentation mock du service de séquences basée sur un fichier JSON.
+ */
+public class SequenceServiceMock implements SequenceService {
+    private final Path file;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private Map<String, Integer> sequences;
+
+    public SequenceServiceMock(Path dataDir) {
+        this.file = dataDir.resolve("sequences.json");
+        load();
+    }
+
+    private void load() {
+        try {
+            if (Files.exists(file)) {
+                sequences = mapper.readValue(file.toFile(), new TypeReference<Map<String, Integer>>(){});
+            } else {
+                sequences = new HashMap<>();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void save() {
+        try {
+            Files.createDirectories(file.getParent());
+            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), sequences);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized String nextNumber(DocumentType type, LocalDate date) {
+        String year = String.valueOf(date.getYear());
+        String key = type.name() + "-" + year;
+        int next = sequences.getOrDefault(key, 0) + 1;
+        sequences.put(key, next);
+        save();
+        return prefix(type) + "-" + year + String.format("-%05d", next);
+    }
+
+    private String prefix(DocumentType type) {
+        return switch (type) {
+            case QUOTE -> "DEV";
+            case ORDER -> "CMD";
+            case DELIVERY_NOTE -> "BL";
+            case INVOICE -> "FAC";
+        };
+    }
+}

--- a/src/main/java/com/materiel/client/model/BaseDocument.java
+++ b/src/main/java/com/materiel/client/model/BaseDocument.java
@@ -1,0 +1,55 @@
+package com.materiel.client.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Classe de base pour tous les documents commerciaux.
+ */
+public abstract class BaseDocument {
+    private UUID id;
+    private String number;
+    private LocalDate date = LocalDate.now();
+    private UUID customerId;
+    private String customerName;
+    private List<DocumentLine> lines = new ArrayList<>();
+    private BigDecimal totalHT = BigDecimal.ZERO;
+    private BigDecimal totalTVA = BigDecimal.ZERO;
+    private BigDecimal totalTTC = BigDecimal.ZERO;
+    private DocumentStatus status = DocumentStatus.DRAFT;
+    private String notes;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getNumber() { return number; }
+    public void setNumber(String number) { this.number = number; }
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+    public UUID getCustomerId() { return customerId; }
+    public void setCustomerId(UUID customerId) { this.customerId = customerId; }
+    public String getCustomerName() { return customerName; }
+    public void setCustomerName(String customerName) { this.customerName = customerName; }
+    public List<DocumentLine> getLines() { return lines; }
+    public void setLines(List<DocumentLine> lines) { this.lines = lines; }
+    public BigDecimal getTotalHT() { return totalHT; }
+    public BigDecimal getTotalTVA() { return totalTVA; }
+    public BigDecimal getTotalTTC() { return totalTTC; }
+    public DocumentStatus getStatus() { return status; }
+    public void setStatus(DocumentStatus status) { this.status = status; }
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+
+    /**
+     * Recalcule les totaux à partir des lignes.
+     */
+    public void recalcTotals() {
+        totalHT = lines.stream().map(DocumentLine::getTotalHT)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        totalTVA = lines.stream().map(DocumentLine::getTotalTVA)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        totalTTC = totalHT.add(totalTVA);
+    }
+}

--- a/src/main/java/com/materiel/client/model/DeliveryNote.java
+++ b/src/main/java/com/materiel/client/model/DeliveryNote.java
@@ -1,0 +1,18 @@
+package com.materiel.client.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Bon de livraison / Delivery note.
+ */
+public class DeliveryNote extends BaseDocument {
+    private UUID orderId;
+    private List<UUID> interventionIds = new ArrayList<>();
+
+    public UUID getOrderId() { return orderId; }
+    public void setOrderId(UUID orderId) { this.orderId = orderId; }
+    public List<UUID> getInterventionIds() { return interventionIds; }
+    public void setInterventionIds(List<UUID> interventionIds) { this.interventionIds = interventionIds; }
+}

--- a/src/main/java/com/materiel/client/model/DocumentLine.java
+++ b/src/main/java/com/materiel/client/model/DocumentLine.java
@@ -1,0 +1,63 @@
+package com.materiel.client.model;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+
+/**
+ * Ligne d'un document (devis, commande, etc.).
+ */
+public class DocumentLine {
+    private UUID productId;
+    private String label;
+    private BigDecimal quantity = BigDecimal.ZERO;
+    private String unit;
+    private BigDecimal unitPriceHT = BigDecimal.ZERO;
+    private BigDecimal discountPct = BigDecimal.ZERO; // pourcentage 0-100
+    private BigDecimal vatRate = BigDecimal.ZERO; // pourcentage 0-100
+
+    public DocumentLine() {
+    }
+
+    public DocumentLine(UUID productId, String label, BigDecimal quantity, String unit,
+                        BigDecimal unitPriceHT, BigDecimal discountPct, BigDecimal vatRate) {
+        this.productId = productId;
+        this.label = label;
+        this.quantity = quantity;
+        this.unit = unit;
+        this.unitPriceHT = unitPriceHT;
+        this.discountPct = discountPct;
+        this.vatRate = vatRate;
+    }
+
+    public UUID getProductId() { return productId; }
+    public void setProductId(UUID productId) { this.productId = productId; }
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+    public BigDecimal getQuantity() { return quantity; }
+    public void setQuantity(BigDecimal quantity) { this.quantity = quantity; }
+    public String getUnit() { return unit; }
+    public void setUnit(String unit) { this.unit = unit; }
+    public BigDecimal getUnitPriceHT() { return unitPriceHT; }
+    public void setUnitPriceHT(BigDecimal unitPriceHT) { this.unitPriceHT = unitPriceHT; }
+    public BigDecimal getDiscountPct() { return discountPct; }
+    public void setDiscountPct(BigDecimal discountPct) { this.discountPct = discountPct; }
+    public BigDecimal getVatRate() { return vatRate; }
+    public void setVatRate(BigDecimal vatRate) { this.vatRate = vatRate; }
+
+    /**
+     * Total HT de la ligne = qty * prix * (1 - remise).
+     */
+    public BigDecimal getTotalHT() {
+        BigDecimal base = unitPriceHT.multiply(quantity);
+        BigDecimal discount = base.multiply(discountPct).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+        return base.subtract(discount);
+    }
+
+    /**
+     * TVA de la ligne.
+     */
+    public BigDecimal getTotalTVA() {
+        return getTotalHT().multiply(vatRate).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/materiel/client/model/DocumentStatus.java
+++ b/src/main/java/com/materiel/client/model/DocumentStatus.java
@@ -1,0 +1,34 @@
+package com.materiel.client.model;
+
+import java.util.Set;
+
+/**
+ * Statut générique des documents.
+ * Chaque statut connaît les types auxquels il peut s'appliquer.
+ */
+public enum DocumentStatus {
+    DRAFT(DocumentType.QUOTE, DocumentType.ORDER, DocumentType.DELIVERY_NOTE, DocumentType.INVOICE),
+    SENT(DocumentType.QUOTE, DocumentType.INVOICE),
+    ACCEPTED(DocumentType.QUOTE),
+    REFUSED(DocumentType.QUOTE),
+    EXPIRED(DocumentType.QUOTE),
+    CONFIRMED(DocumentType.ORDER),
+    CANCELED(DocumentType.ORDER, DocumentType.INVOICE),
+    SIGNED(DocumentType.DELIVERY_NOTE),
+    LOCKED(DocumentType.DELIVERY_NOTE),
+    PARTIALLY_PAID(DocumentType.INVOICE),
+    PAID(DocumentType.INVOICE);
+
+    private final Set<DocumentType> types;
+
+    DocumentStatus(DocumentType... types) {
+        this.types = Set.of(types);
+    }
+
+    /**
+     * Indique si le statut est applicable au type de document fourni.
+     */
+    public boolean isAllowed(DocumentType type) {
+        return types.contains(type);
+    }
+}

--- a/src/main/java/com/materiel/client/model/DocumentType.java
+++ b/src/main/java/com/materiel/client/model/DocumentType.java
@@ -1,0 +1,11 @@
+package com.materiel.client.model;
+
+/**
+ * Type générique de document.
+ */
+public enum DocumentType {
+    QUOTE,
+    ORDER,
+    DELIVERY_NOTE,
+    INVOICE
+}

--- a/src/main/java/com/materiel/client/model/Invoice.java
+++ b/src/main/java/com/materiel/client/model/Invoice.java
@@ -1,0 +1,18 @@
+package com.materiel.client.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Facture / Invoice.
+ */
+public class Invoice extends BaseDocument {
+    private UUID quoteId;
+    private List<UUID> deliveryNoteIds = new ArrayList<>();
+
+    public UUID getQuoteId() { return quoteId; }
+    public void setQuoteId(UUID quoteId) { this.quoteId = quoteId; }
+    public List<UUID> getDeliveryNoteIds() { return deliveryNoteIds; }
+    public void setDeliveryNoteIds(List<UUID> deliveryNoteIds) { this.deliveryNoteIds = deliveryNoteIds; }
+}

--- a/src/main/java/com/materiel/client/model/Order.java
+++ b/src/main/java/com/materiel/client/model/Order.java
@@ -1,0 +1,13 @@
+package com.materiel.client.model;
+
+import java.util.UUID;
+
+/**
+ * Commande/Order.
+ */
+public class Order extends BaseDocument {
+    private UUID quoteId;
+
+    public UUID getQuoteId() { return quoteId; }
+    public void setQuoteId(UUID quoteId) { this.quoteId = quoteId; }
+}

--- a/src/main/java/com/materiel/client/model/Quote.java
+++ b/src/main/java/com/materiel/client/model/Quote.java
@@ -1,0 +1,7 @@
+package com.materiel.client.model;
+
+/**
+ * Devis/Quote.
+ */
+public class Quote extends BaseDocument {
+}

--- a/src/main/java/com/materiel/client/service/DeliveryNoteService.java
+++ b/src/main/java/com/materiel/client/service/DeliveryNoteService.java
@@ -1,0 +1,25 @@
+package com.materiel.client.service;
+
+import com.materiel.client.model.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service de gestion des bons de livraison.
+ */
+public interface DeliveryNoteService {
+    List<DeliveryNote> list();
+    DeliveryNote get(UUID id);
+    DeliveryNote create(DeliveryNote note);
+    DeliveryNote update(DeliveryNote note);
+    void delete(UUID id);
+    DeliveryNote transition(UUID id, DocumentStatus newStatus);
+    String generateNumber(LocalDate date);
+
+    /**
+     * Génère un bon de livraison à partir d'une commande.
+     */
+    DeliveryNote fromOrder(Order order, List<UUID> interventionIds);
+}

--- a/src/main/java/com/materiel/client/service/InvoiceService.java
+++ b/src/main/java/com/materiel/client/service/InvoiceService.java
@@ -1,0 +1,23 @@
+package com.materiel.client.service;
+
+import com.materiel.client.model.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service de gestion des factures.
+ */
+public interface InvoiceService {
+    List<Invoice> list();
+    Invoice get(UUID id);
+    Invoice create(Invoice invoice);
+    Invoice update(Invoice invoice);
+    void delete(UUID id);
+    Invoice transition(UUID id, DocumentStatus newStatus);
+    String generateNumber(LocalDate date);
+
+    Invoice fromQuote(Quote quote);
+    Invoice fromDeliveryNotes(List<DeliveryNote> notes);
+}

--- a/src/main/java/com/materiel/client/service/OrderService.java
+++ b/src/main/java/com/materiel/client/service/OrderService.java
@@ -1,0 +1,25 @@
+package com.materiel.client.service;
+
+import com.materiel.client.model.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service de gestion des commandes.
+ */
+public interface OrderService {
+    List<Order> list();
+    Order get(UUID id);
+    Order create(Order order);
+    Order update(Order order);
+    void delete(UUID id);
+    Order transition(UUID id, DocumentStatus newStatus);
+    String generateNumber(LocalDate date);
+
+    /**
+     * Crée une commande à partir d'un devis.
+     */
+    Order fromQuote(Quote quote);
+}

--- a/src/main/java/com/materiel/client/service/PdfRenderer.java
+++ b/src/main/java/com/materiel/client/service/PdfRenderer.java
@@ -1,0 +1,13 @@
+package com.materiel.client.service;
+
+import com.materiel.client.model.DocumentType;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+/**
+ * Interface de rendu PDF. Implémentation minimale pour les tests.
+ */
+public interface PdfRenderer {
+    Path render(DocumentType type, UUID id);
+}

--- a/src/main/java/com/materiel/client/service/SequenceService.java
+++ b/src/main/java/com/materiel/client/service/SequenceService.java
@@ -1,0 +1,12 @@
+package com.materiel.client.service;
+
+import com.materiel.client.model.DocumentType;
+
+import java.time.LocalDate;
+
+/**
+ * Service de numérotation des documents.
+ */
+public interface SequenceService {
+    String nextNumber(DocumentType type, LocalDate date);
+}

--- a/src/test/java/com/materiel/client/service/ServiceMockTest.java
+++ b/src/test/java/com/materiel/client/service/ServiceMockTest.java
@@ -1,0 +1,102 @@
+package com.materiel.client.service;
+
+import com.materiel.client.mock.DeliveryNoteServiceMock;
+import com.materiel.client.mock.InvoiceServiceMock;
+import com.materiel.client.mock.OrderServiceMock;
+import com.materiel.client.mock.SequenceServiceMock;
+import com.materiel.client.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceMockTest {
+
+    private Path dataDir;
+    private SequenceServiceMock sequenceService;
+    private OrderServiceMock orderService;
+    private DeliveryNoteServiceMock deliveryNoteService;
+    private InvoiceServiceMock invoiceService;
+
+    @BeforeEach
+    void setup() throws Exception {
+        dataDir = Files.createTempDirectory("gm-data");
+        sequenceService = new SequenceServiceMock(dataDir);
+        orderService = new OrderServiceMock(dataDir, sequenceService);
+        deliveryNoteService = new DeliveryNoteServiceMock(dataDir, sequenceService);
+        invoiceService = new InvoiceServiceMock(dataDir, sequenceService);
+    }
+
+    @Test
+    void fromQuoteToOrder() {
+        Quote quote = new Quote();
+        quote.setId(UUID.randomUUID());
+        quote.setCustomerId(UUID.randomUUID());
+        quote.setCustomerName("Client");
+        quote.setStatus(DocumentStatus.ACCEPTED);
+        quote.setLines(List.of(
+                new DocumentLine(UUID.randomUUID(), "Prod1", BigDecimal.valueOf(2), "u", BigDecimal.valueOf(100), BigDecimal.valueOf(10), BigDecimal.valueOf(20)),
+                new DocumentLine(UUID.randomUUID(), "Prod2", BigDecimal.ONE, "u", BigDecimal.valueOf(50), BigDecimal.ZERO, BigDecimal.valueOf(20))
+        ));
+        quote.recalcTotals();
+
+        Order order = orderService.fromQuote(quote);
+        assertThat(order.getQuoteId()).isEqualTo(quote.getId());
+        assertThat(order.getStatus()).isEqualTo(DocumentStatus.CONFIRMED);
+        assertThat(order.getNumber()).isNotNull();
+        assertThat(order.getTotalHT()).isEqualByComparingTo(BigDecimal.valueOf(230));
+        assertThat(order.getTotalTVA()).isEqualByComparingTo(BigDecimal.valueOf(46));
+        assertThat(order.getTotalTTC()).isEqualByComparingTo(BigDecimal.valueOf(276));
+    }
+
+    @Test
+    void fromOrderToDeliveryNote() {
+        Order order = new Order();
+        order.setId(UUID.randomUUID());
+        order.setCustomerId(UUID.randomUUID());
+        order.setCustomerName("Client");
+        order.setLines(List.of(
+                new DocumentLine(UUID.randomUUID(), "Prod1", BigDecimal.ONE, "u", BigDecimal.valueOf(100), BigDecimal.ZERO, BigDecimal.valueOf(20))
+        ));
+        order.recalcTotals();
+        orderService.create(order);
+
+        DeliveryNote bl = deliveryNoteService.fromOrder(order, List.of(UUID.randomUUID()));
+        assertThat(bl.getOrderId()).isEqualTo(order.getId());
+        assertThat(bl.getInterventionIds()).hasSize(1);
+        assertThat(bl.getTotalHT()).isEqualByComparingTo(order.getTotalHT());
+    }
+
+    @Test
+    void fromBLToInvoice() {
+        DeliveryNote bl1 = new DeliveryNote();
+        bl1.setId(UUID.randomUUID());
+        bl1.setCustomerId(UUID.randomUUID());
+        bl1.setCustomerName("Client");
+        bl1.setLines(List.of(
+                new DocumentLine(UUID.randomUUID(), "Prod1", BigDecimal.ONE, "u", BigDecimal.valueOf(100), BigDecimal.ZERO, BigDecimal.valueOf(20))
+        ));
+        bl1.recalcTotals();
+        deliveryNoteService.create(bl1);
+
+        DeliveryNote bl2 = new DeliveryNote();
+        bl2.setId(UUID.randomUUID());
+        bl2.setCustomerId(bl1.getCustomerId());
+        bl2.setCustomerName("Client");
+        bl2.setLines(List.of(
+                new DocumentLine(UUID.randomUUID(), "Prod2", BigDecimal.ONE, "u", BigDecimal.valueOf(50), BigDecimal.ZERO, BigDecimal.valueOf(20))
+        ));
+        bl2.recalcTotals();
+        deliveryNoteService.create(bl2);
+
+        Invoice invoice = invoiceService.fromDeliveryNotes(List.of(bl1, bl2));
+        assertThat(invoice.getDeliveryNoteIds()).containsExactlyInAnyOrder(bl1.getId(), bl2.getId());
+        assertThat(invoice.getTotalTVA()).isEqualByComparingTo(bl1.getTotalTVA().add(bl2.getTotalTVA()));
+    }
+}


### PR DESCRIPTION
## Résumé
- Ajout des modèles génériques de documents (types, statuts, lignes, base)
- Implémentation des services mock pour commandes, bons de livraison et factures avec conversions
- Ajout du service de séquence JSON et tests de conversion

## Tests
- `mvn -q -DskipTests=false test` *(échec: PluginResolutionException – Network is unreachable)*
- `mvn -q -DskipTests compile` *(échec: PluginResolutionException – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c17c33260c8330b3a12c5ed5087823