### PR TITLE
Add document line model and totals utility

### DIFF
--- a/src/main/java/com/materiel/client/model/BaseDocument.java
+++ b/src/main/java/com/materiel/client/model/BaseDocument.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import com.materiel.client.util.DocumentTotalsCalculator;
 
 /**
  * Classe de base pour tous les documents commerciaux.
@@ -46,10 +47,9 @@ public abstract class BaseDocument {
      * Recalcule les totaux à partir des lignes.
      */
     public void recalcTotals() {
-        totalHT = lines.stream().map(DocumentLine::getTotalHT)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-        totalTVA = lines.stream().map(DocumentLine::getTotalTVA)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-        totalTTC = totalHT.add(totalTVA);
+        DocumentTotalsCalculator.Totaux t = DocumentTotalsCalculator.compute(lines);
+        this.totalHT = t.totalHT;
+        this.totalTVA = t.totalTVA;
+        this.totalTTC = t.totalTTC;
     }
 }

--- a/src/main/java/com/materiel/client/model/DocumentLine.java
+++ b/src/main/java/com/materiel/client/model/DocumentLine.java
@@ -1,63 +1,32 @@
 package com.materiel.client.model;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.UUID;
 
 /**
  * Ligne d'un document (devis, commande, etc.).
  */
 public class DocumentLine {
-    private UUID productId;
-    private String label;
-    private BigDecimal quantity = BigDecimal.ZERO;
-    private String unit;
-    private BigDecimal unitPriceHT = BigDecimal.ZERO;
-    private BigDecimal discountPct = BigDecimal.ZERO; // pourcentage 0-100
-    private BigDecimal vatRate = BigDecimal.ZERO; // pourcentage 0-100
+    private UUID id = UUID.randomUUID();
+    private String designation; // désignation/description
+    private String unite;       // "h", "jour", "pièce", etc.
+    private BigDecimal quantite = BigDecimal.ONE;
+    private BigDecimal prixUnitaireHT = BigDecimal.ZERO;
+    private BigDecimal remisePct = BigDecimal.ZERO;   // 0..100
+    private BigDecimal tvaPct = new BigDecimal("20.0");
 
-    public DocumentLine() {
-    }
-
-    public DocumentLine(UUID productId, String label, BigDecimal quantity, String unit,
-                        BigDecimal unitPriceHT, BigDecimal discountPct, BigDecimal vatRate) {
-        this.productId = productId;
-        this.label = label;
-        this.quantity = quantity;
-        this.unit = unit;
-        this.unitPriceHT = unitPriceHT;
-        this.discountPct = discountPct;
-        this.vatRate = vatRate;
-    }
-
-    public UUID getProductId() { return productId; }
-    public void setProductId(UUID productId) { this.productId = productId; }
-    public String getLabel() { return label; }
-    public void setLabel(String label) { this.label = label; }
-    public BigDecimal getQuantity() { return quantity; }
-    public void setQuantity(BigDecimal quantity) { this.quantity = quantity; }
-    public String getUnit() { return unit; }
-    public void setUnit(String unit) { this.unit = unit; }
-    public BigDecimal getUnitPriceHT() { return unitPriceHT; }
-    public void setUnitPriceHT(BigDecimal unitPriceHT) { this.unitPriceHT = unitPriceHT; }
-    public BigDecimal getDiscountPct() { return discountPct; }
-    public void setDiscountPct(BigDecimal discountPct) { this.discountPct = discountPct; }
-    public BigDecimal getVatRate() { return vatRate; }
-    public void setVatRate(BigDecimal vatRate) { this.vatRate = vatRate; }
-
-    /**
-     * Total HT de la ligne = qty * prix * (1 - remise).
-     */
-    public BigDecimal getTotalHT() {
-        BigDecimal base = unitPriceHT.multiply(quantity);
-        BigDecimal discount = base.multiply(discountPct).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
-        return base.subtract(discount);
-    }
-
-    /**
-     * TVA de la ligne.
-     */
-    public BigDecimal getTotalTVA() {
-        return getTotalHT().multiply(vatRate).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
-    }
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getDesignation() { return designation; }
+    public void setDesignation(String designation) { this.designation = designation; }
+    public String getUnite() { return unite; }
+    public void setUnite(String unite) { this.unite = unite; }
+    public BigDecimal getQuantite() { return quantite; }
+    public void setQuantite(BigDecimal quantite) { this.quantite = quantite; }
+    public BigDecimal getPrixUnitaireHT() { return prixUnitaireHT; }
+    public void setPrixUnitaireHT(BigDecimal prixUnitaireHT) { this.prixUnitaireHT = prixUnitaireHT; }
+    public BigDecimal getRemisePct() { return remisePct; }
+    public void setRemisePct(BigDecimal remisePct) { this.remisePct = remisePct; }
+    public BigDecimal getTvaPct() { return tvaPct; }
+    public void setTvaPct(BigDecimal tvaPct) { this.tvaPct = tvaPct; }
 }

--- a/src/main/java/com/materiel/client/util/DocumentTotalsCalculator.java
+++ b/src/main/java/com/materiel/client/util/DocumentTotalsCalculator.java
@@ -1,0 +1,32 @@
+package com.materiel.client.util;
+
+import com.materiel.client.model.DocumentLine;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+public final class DocumentTotalsCalculator {
+    private DocumentTotalsCalculator(){}
+    public static class Totaux {
+        public BigDecimal totalHT, totalTVA, totalTTC;
+        public Totaux(BigDecimal ht, BigDecimal tva, BigDecimal ttc){ this.totalHT=ht; this.totalTVA=tva; this.totalTTC=ttc; }
+    }
+    public static Totaux compute(List<DocumentLine> lines){
+        BigDecimal ht = BigDecimal.ZERO, tva = BigDecimal.ZERO;
+        for (DocumentLine l : lines){
+            if (l==null) continue;
+            BigDecimal q = nz(l.getQuantite());
+            BigDecimal pu = nz(l.getPrixUnitaireHT());
+            BigDecimal rem = nz(l.getRemisePct()).divide(new BigDecimal("100"), 6, RoundingMode.HALF_UP);
+            BigDecimal base = q.multiply(pu).multiply(BigDecimal.ONE.subtract(rem));
+            base = base.setScale(2, RoundingMode.HALF_UP);
+            BigDecimal tvaPct = nz(l.getTvaPct()).divide(new BigDecimal("100"), 6, RoundingMode.HALF_UP);
+            BigDecimal tvaL = base.multiply(tvaPct).setScale(2, RoundingMode.HALF_UP);
+            ht = ht.add(base);
+            tva = tva.add(tvaL);
+        }
+        BigDecimal ttc = ht.add(tva).setScale(2, RoundingMode.HALF_UP);
+        return new Totaux(ht.setScale(2, RoundingMode.HALF_UP), tva.setScale(2, RoundingMode.HALF_UP), ttc);
+    }
+    private static BigDecimal nz(BigDecimal b){ return b==null? BigDecimal.ZERO : b; }
+}

--- a/src/main/java/com/materiel/client/view/doc/DocumentLineTable.java
+++ b/src/main/java/com/materiel/client/view/doc/DocumentLineTable.java
@@ -1,0 +1,54 @@
+package com.materiel.client.view.doc;
+
+import com.materiel.client.model.DocumentLine;
+
+import javax.swing.*;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.math.BigDecimal;
+import java.util.List;
+
+public class DocumentLineTable extends JPanel {
+  private final JTable table;
+  private final DocumentLineTableModel model;
+
+  public DocumentLineTable(List<DocumentLine> lines){
+    super(new BorderLayout());
+    model = new DocumentLineTableModel(lines);
+    table = new JTable(model);
+    table.setRowHeight(28);
+    table.putClientProperty("FlatLaf.styleClass", "table");
+    table.setAutoCreateRowSorter(true);
+    table.setRowSorter(new TableRowSorter<>(table.getModel()));
+
+    // éditeurs simples : spinners pour numériques + combo TVA
+    setEditors();
+
+    JToolBar tb = new JToolBar();
+    tb.setFloatable(false);
+    JButton add = new JButton("Ajouter");
+    JButton del = new JButton("Supprimer");
+    JButton up  = new JButton("Monter");
+    JButton dn  = new JButton("Descendre");
+    add.addActionListener(e -> model.addEmptyLine());
+    del.addActionListener(e -> model.removeAt(table.getSelectedRow()));
+    up.addActionListener(e -> model.moveUp(table.getSelectedRow()));
+    dn.addActionListener(e -> model.moveDown(table.getSelectedRow()));
+    tb.add(add); tb.add(del); tb.addSeparator(); tb.add(up); tb.add(dn);
+
+    add(tb, BorderLayout.NORTH);
+    add(new JScrollPane(table), BorderLayout.CENTER);
+  }
+
+  private void setEditors(){
+    table.getColumnModel().getColumn(1).setCellEditor(new DefaultCellEditor(new JFormattedTextField()));
+    table.getColumnModel().getColumn(3).setCellEditor(new DefaultCellEditor(new JFormattedTextField()));
+    table.getColumnModel().getColumn(4).setCellEditor(new DefaultCellEditor(new JFormattedTextField()));
+    JComboBox<BigDecimal> tva = new JComboBox<>(new BigDecimal[]{
+      new BigDecimal("20.0"), new BigDecimal("10.0"), new BigDecimal("5.5"), new BigDecimal("0.0")
+    });
+    table.getColumnModel().getColumn(5).setCellEditor(new DefaultCellEditor(tva));
+  }
+
+  public DocumentLineTableModel getModel(){ return model; }
+}

--- a/src/main/java/com/materiel/client/view/doc/DocumentLineTableModel.java
+++ b/src/main/java/com/materiel/client/view/doc/DocumentLineTableModel.java
@@ -1,0 +1,83 @@
+package com.materiel.client.view.doc;
+import com.materiel.client.model.DocumentLine;
+import javax.swing.table.AbstractTableModel;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Collections;
+import static java.math.RoundingMode.HALF_UP;
+
+public class DocumentLineTableModel extends AbstractTableModel {
+  private final String[] cols = {"Désignation","Qté","Unité","PU HT","Remise %","TVA %","Ligne HT","TVA €","Ligne TTC"};
+  private final Class<?>[] types = {String.class, BigDecimal.class, String.class, BigDecimal.class, BigDecimal.class, BigDecimal.class, BigDecimal.class, BigDecimal.class, BigDecimal.class};
+  private final List<DocumentLine> data;
+  public DocumentLineTableModel(List<DocumentLine> lines){ this.data = lines; }
+
+  @Override public int getRowCount(){ return data.size(); }
+  @Override public int getColumnCount(){ return cols.length; }
+  @Override public String getColumnName(int c){ return cols[c]; }
+  @Override public Class<?> getColumnClass(int c){ return types[c]; }
+  @Override public boolean isCellEditable(int r, int c){ return c <= 5; } // 0..5 éditables, totaux en lecture seule
+
+  @Override public Object getValueAt(int r, int c){
+    DocumentLine l = data.get(r);
+    switch(c){
+      case 0: return l.getDesignation();
+      case 1: return l.getQuantite();
+      case 2: return l.getUnite();
+      case 3: return l.getPrixUnitaireHT();
+      case 4: return l.getRemisePct();
+      case 5: return l.getTvaPct();
+      case 6: { // HT ligne
+        var rem = nz(l.getRemisePct()).divide(new BigDecimal("100"), 6, HALF_UP);
+        var base = nz(l.getQuantite()).multiply(nz(l.getPrixUnitaireHT())).multiply(BigDecimal.ONE.subtract(rem));
+        return base.setScale(2, HALF_UP);
+      }
+      case 7: { // TVA €
+        var ht = (BigDecimal) getValueAt(r,6);
+        var tvaPct = nz(l.getTvaPct()).divide(new BigDecimal("100"), 6, HALF_UP);
+        return ht.multiply(tvaPct).setScale(2, HALF_UP);
+      }
+      case 8: { // TTC
+        var ht = (BigDecimal) getValueAt(r,6);
+        var tva = (BigDecimal) getValueAt(r,7);
+        return ht.add(tva).setScale(2, HALF_UP);
+      }
+    }
+    return null;
+  }
+
+  @Override public void setValueAt(Object aValue, int r, int c){
+    DocumentLine l = data.get(r);
+    switch(c){
+      case 0: l.setDesignation((String)aValue); break;
+      case 1: l.setQuantite(toBD(aValue)); break;
+      case 2: l.setUnite((String)aValue); break;
+      case 3: l.setPrixUnitaireHT(toBD(aValue)); break;
+      case 4: l.setRemisePct(toBD(aValue)); break;
+      case 5: l.setTvaPct(toBD(aValue)); break;
+    }
+    fireTableRowsUpdated(r,r);
+  }
+
+  public void addEmptyLine(){
+    DocumentLine l = new DocumentLine();
+    l.setDesignation("Nouvelle ligne");
+    l.setUnite("u");
+    l.setQuantite(new BigDecimal("1"));
+    l.setPrixUnitaireHT(new BigDecimal("0.00"));
+    l.setRemisePct(new BigDecimal("0"));
+    l.setTvaPct(new BigDecimal("20.0"));
+    data.add(l);
+    int r = data.size()-1; fireTableRowsInserted(r, r);
+  }
+  public void removeAt(int r){ if(r>=0 && r<data.size()){ data.remove(r); fireTableRowsDeleted(r,r);} }
+  public void moveUp(int r){ if(r>0){ Collections.swap(data, r, r-1); fireTableRowsUpdated(r-1, r);} }
+  public void moveDown(int r){ if(r>=0 && r<data.size()-1){ Collections.swap(data, r, r+1); fireTableRowsUpdated(r, r+1);} }
+
+  private static BigDecimal toBD(Object v){
+    if (v==null) return BigDecimal.ZERO;
+    if (v instanceof BigDecimal) return (BigDecimal) v;
+    return new BigDecimal(v.toString().replace(",", "."));
+  }
+  private static BigDecimal nz(BigDecimal b){ return b==null? BigDecimal.ZERO : b; }
+}

--- a/src/main/java/com/materiel/client/view/doc/DocumentTotalsPanel.java
+++ b/src/main/java/com/materiel/client/view/doc/DocumentTotalsPanel.java
@@ -1,0 +1,27 @@
+package com.materiel.client.view.doc;
+
+import com.materiel.client.model.DocumentLine;
+import com.materiel.client.util.DocumentTotalsCalculator;
+
+import javax.swing.*;
+import java.awt.*;
+import java.math.BigDecimal;
+import java.util.List;
+
+public class DocumentTotalsPanel extends JPanel {
+  private final JLabel ht = new JLabel("0.00 €");
+  private final JLabel tva = new JLabel("0.00 €");
+  private final JLabel ttc = new JLabel("0.00 €");
+
+  public DocumentTotalsPanel(){
+    super(new GridLayout(3,2,8,4));
+    add(new JLabel("Total HT :")); add(ht);
+    add(new JLabel("Total TVA :")); add(tva);
+    add(new JLabel("Total TTC :")); add(ttc);
+  }
+  public void bind(List<DocumentLine> lines){
+    var t = DocumentTotalsCalculator.compute(lines);
+    ht.setText(fmt(t.totalHT)); tva.setText(fmt(t.totalTVA)); ttc.setText(fmt(t.totalTTC));
+  }
+  private static String fmt(BigDecimal v){ return String.format("%,.2f €", v); }
+}

--- a/src/test/java/com/materiel/client/service/ConversionsTest.java
+++ b/src/test/java/com/materiel/client/service/ConversionsTest.java
@@ -1,0 +1,61 @@
+package com.materiel.client.service;
+
+import com.materiel.client.mock.DeliveryNoteServiceMock;
+import com.materiel.client.mock.InvoiceServiceMock;
+import com.materiel.client.mock.OrderServiceMock;
+import com.materiel.client.mock.SequenceServiceMock;
+import com.materiel.client.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConversionsTest {
+    @Test
+    void testConversionsChain() throws Exception {
+        Path temp = Files.createTempDirectory("data");
+        SequenceServiceMock seq = new SequenceServiceMock(temp);
+        OrderServiceMock orderService = new OrderServiceMock(temp, seq);
+        DeliveryNoteServiceMock blService = new DeliveryNoteServiceMock(temp, seq);
+        InvoiceServiceMock invoiceService = new InvoiceServiceMock(temp, seq);
+
+        Quote quote = new Quote();
+        quote.setId(UUID.randomUUID());
+        quote.setCustomerId(UUID.randomUUID());
+        quote.setCustomerName("Client");
+        DocumentLine line = new DocumentLine();
+        line.setDesignation("Prod");
+        line.setUnite("u");
+        line.setQuantite(new BigDecimal("3"));
+        line.setPrixUnitaireHT(new BigDecimal("10"));
+        line.setRemisePct(BigDecimal.ZERO);
+        line.setTvaPct(new BigDecimal("20"));
+        quote.setLines(List.of(line));
+        quote.recalcTotals();
+
+        Order order = orderService.fromQuote(quote);
+        assertEquals(1, order.getLines().size());
+        assertEquals("Prod", order.getLines().get(0).getDesignation());
+        assertEquals(quote.getTotalTTC(), order.getTotalTTC());
+
+        DeliveryNote bl = blService.fromOrder(order, List.of());
+        assertEquals(1, bl.getLines().size());
+        assertEquals("Prod", bl.getLines().get(0).getDesignation());
+        assertEquals(order.getTotalTTC(), bl.getTotalTTC());
+
+        Invoice invoice = invoiceService.fromDeliveryNotes(List.of(bl));
+        assertEquals(1, invoice.getLines().size());
+        assertEquals("Prod", invoice.getLines().get(0).getDesignation());
+        assertEquals(bl.getTotalTTC(), invoice.getTotalTTC());
+
+        Invoice inv2 = invoiceService.fromQuote(quote);
+        assertEquals(1, inv2.getLines().size());
+        assertEquals("Prod", inv2.getLines().get(0).getDesignation());
+        assertEquals(quote.getTotalTTC(), inv2.getTotalTTC());
+    }
+}

--- a/src/test/java/com/materiel/client/util/DocumentTotalsCalculatorTest.java
+++ b/src/test/java/com/materiel/client/util/DocumentTotalsCalculatorTest.java
@@ -1,0 +1,34 @@
+package com.materiel.client.util;
+
+import com.materiel.client.model.DocumentLine;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentTotalsCalculatorTest {
+    @Test
+    void computeTotals() {
+        DocumentLine l1 = new DocumentLine();
+        l1.setDesignation("L1");
+        l1.setQuantite(new BigDecimal("2"));
+        l1.setPrixUnitaireHT(new BigDecimal("100"));
+        l1.setRemisePct(new BigDecimal("10"));
+        l1.setTvaPct(new BigDecimal("20"));
+
+        DocumentLine l2 = new DocumentLine();
+        l2.setDesignation("L2");
+        l2.setQuantite(new BigDecimal("1"));
+        l2.setPrixUnitaireHT(new BigDecimal("50"));
+        l2.setRemisePct(BigDecimal.ZERO);
+        l2.setTvaPct(new BigDecimal("5.5"));
+
+        var tot = DocumentTotalsCalculator.compute(Arrays.asList(l1, l2));
+
+        assertEquals(new BigDecimal("230.00"), tot.totalHT);
+        assertEquals(new BigDecimal("38.75"), tot.totalTVA);
+        assertEquals(new BigDecimal("268.75"), tot.totalTTC);
+    }
+}


### PR DESCRIPTION
## Summary
- rework `DocumentLine` with explicit designation, unit, quantity and VAT fields
- introduce `DocumentTotalsCalculator` and integrate into `BaseDocument` for total recomputation
- provide reusable Swing table and totals panel for editing document lines
- add unit tests for totals computation and document conversions

## Testing
- ❌ `mvn -q -DskipTests compile` *(plugin resolution failure: Network is unreachable)*
- ❌ `mvn -q -DskipTests=false test` *(plugin resolution failure: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c181d211648330a04576f139de75cc