### PR TITLE
feat: add backend quote service via openapi

### DIFF
--- a/openapi/gestion-materiel-v1.yaml
+++ b/openapi/gestion-materiel-v1.yaml
@@ -1,0 +1,145 @@
+openapi: 3.0.1
+info:
+  title: Gestion Materiel API
+  version: 1.0.0
+servers:
+  - url: http://localhost
+paths:
+  /api/v1/quotes:
+    get:
+      operationId: listQuotes
+      responses:
+        '200':
+          description: List quotes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Quote'
+    post:
+      operationId: createQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+  /api/v1/quotes/{id}:
+    get:
+      operationId: getQuote
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Quote by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '404':
+          description: Not found
+    put:
+      operationId: updateQuote
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '404':
+          description: Not found
+    delete:
+      operationId: deleteQuote
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Deleted
+components:
+  schemas:
+    Quote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+        date:
+          type: string
+          format: date
+        customerId:
+          type: string
+          format: uuid
+        customerName:
+          type: string
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentLine'
+        totalHT:
+          type: number
+        totalTVA:
+          type: number
+        totalTTC:
+          type: number
+        status:
+          type: string
+          enum:
+            - DRAFT
+            - SENT
+            - ACCEPTED
+            - REFUSED
+            - EXPIRED
+        notes:
+          type: string
+    DocumentLine:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        designation:
+          type: string
+        unite:
+          type: string
+        quantite:
+          type: number
+        prixUnitaireHT:
+          type: number
+        remisePct:
+          type: number
+        tvaPct:
+          type: number

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+
+        <!-- HTTP client -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
         
         <!-- Logging -->
         <dependency>
@@ -92,6 +99,13 @@
             <version>3.17.1</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>
@@ -110,6 +124,34 @@
                 </configuration>
             </plugin>
             
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/openapi/gestion-materiel-v1.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>native</library>
+                            <dateLibrary>java8</dateLibrary>
+                            <serializationLibrary>jackson</serializationLibrary>
+                            <apiPackage>com.materiel.client.backend.api</apiPackage>
+                            <invokerPackage>com.materiel.client.backend.invoker</invokerPackage>
+                            <modelPackage>com.materiel.client.backend.model</modelPackage>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <configOptions>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <addCompileSourceRoot>true</addCompileSourceRoot>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
 
         <resources>

--- a/src/main/java/com/materiel/client/GestionMaterielApp.java
+++ b/src/main/java/com/materiel/client/GestionMaterielApp.java
@@ -17,6 +17,7 @@ public class GestionMaterielApp {
     
     public static void main(String[] args) {
         System.out.println("PATCH_DOC_FLOW_APPLIED");
+        System.out.println("API_WIRING_OK");
         // Configuration du Look & Feel FlatLaf
         try {
             UIManager.setLookAndFeel(new FlatLightLaf());

--- a/src/main/java/com/materiel/client/config/AppConfig.java
+++ b/src/main/java/com/materiel/client/config/AppConfig.java
@@ -1,61 +1,64 @@
 package com.materiel.client.config;
 
-import java.util.prefs.Preferences;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 /**
  * Configuration globale de l'application (Singleton)
  */
 public class AppConfig {
     private static AppConfig instance;
-    private static final String PREF_DATA_MODE = "dataMode";
-    private static final String PREF_API_BASE_URL = "apiBaseUrl";
-    
-    private final Preferences prefs;
+
     private DataMode dataMode;
     private String apiBaseUrl;
-    
+    private String apiToken;
+    private String apiBasicUser;
+    private String apiBasicPass;
+
     private AppConfig() {
-        prefs = Preferences.userNodeForPackage(AppConfig.class);
         loadConfiguration();
     }
-    
-    public static AppConfig getInstance() {
+
+    public static synchronized AppConfig getInstance() {
         if (instance == null) {
             instance = new AppConfig();
         }
         return instance;
     }
-    
+
     private void loadConfiguration() {
-        String mode = prefs.get(PREF_DATA_MODE, DataMode.MOCK_JSON.name());
-        dataMode = DataMode.valueOf(mode);
-        apiBaseUrl = prefs.get(PREF_API_BASE_URL, "http://localhost:8080");
+        Properties props = new Properties();
+        try (InputStream in = AppConfig.class.getClassLoader().getResourceAsStream("application.properties")) {
+            if (in != null) {
+                props.load(in);
+            }
+        } catch (IOException e) {
+            // ignore, use defaults
+        }
+
+        String modeProp = System.getProperty("app.mode", props.getProperty("app.mode", "mock"));
+        this.dataMode = "backend".equalsIgnoreCase(modeProp) ? DataMode.BACKEND_API : DataMode.MOCK_JSON;
+
+        this.apiBaseUrl = System.getProperty("api.baseUrl", props.getProperty("api.baseUrl", "http://localhost:8080"));
+        this.apiToken = System.getProperty("api.token", props.getProperty("api.token"));
+        this.apiBasicUser = System.getProperty("api.basic.user", props.getProperty("api.basic.user"));
+        this.apiBasicPass = System.getProperty("api.basic.pass", props.getProperty("api.basic.pass"));
     }
-    
-    public void saveConfiguration() {
-        prefs.put(PREF_DATA_MODE, dataMode.name());
-        prefs.put(PREF_API_BASE_URL, apiBaseUrl);
-    }
-    
-    // Getters & Setters
+
     public DataMode getDataMode() { return dataMode; }
-    public void setDataMode(DataMode dataMode) { 
-        this.dataMode = dataMode; 
-        saveConfiguration();
-    }
-    
+    public void setDataMode(DataMode dataMode) { this.dataMode = dataMode; }
+
     public String getApiBaseUrl() { return apiBaseUrl; }
-    public void setApiBaseUrl(String apiBaseUrl) { 
-        this.apiBaseUrl = apiBaseUrl; 
-        saveConfiguration();
-    }
-    
-    public boolean isBackendMode() {
-        return dataMode == DataMode.BACKEND_API;
-    }
-    
-    public boolean isMockMode() {
-        return dataMode == DataMode.MOCK_JSON;
-    }
+    public void setApiBaseUrl(String apiBaseUrl) { this.apiBaseUrl = apiBaseUrl; }
+
+    public String getApiToken() { return apiToken; }
+    public String getApiBasicUser() { return apiBasicUser; }
+    public String getApiBasicPass() { return apiBasicPass; }
+
+    public boolean isBackendMode() { return dataMode == DataMode.BACKEND_API; }
+    public boolean isMockMode() { return dataMode == DataMode.MOCK_JSON; }
+
+    /** Reset singleton (utile pour les tests) */
+    public static void reset() { instance = null; }
 }
- 

--- a/src/main/java/com/materiel/client/mock/QuoteServiceMock.java
+++ b/src/main/java/com/materiel/client/mock/QuoteServiceMock.java
@@ -1,0 +1,56 @@
+package com.materiel.client.mock;
+
+import com.materiel.client.backend.model.Quote;
+import com.materiel.client.service.QuoteService;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Implémentation mock du service de devis.
+ */
+public class QuoteServiceMock implements QuoteService {
+    private final JsonStore<Quote> store;
+    private final List<Quote> cache;
+
+    public QuoteServiceMock(Path dataDir) {
+        this.store = new JsonStore<>(dataDir.resolve("quotes.json"), Quote[].class);
+        this.cache = store.load();
+    }
+
+    @Override
+    public List<Quote> list() {
+        return new ArrayList<>(cache);
+    }
+
+    @Override
+    public Quote get(UUID id) {
+        return cache.stream().filter(q -> id.equals(q.getId())).findFirst().orElse(null);
+    }
+
+    @Override
+    public Quote create(Quote quote) {
+        if (quote.getId() == null) {
+            quote.setId(UUID.randomUUID());
+        }
+        cache.add(quote);
+        store.save(cache);
+        return quote;
+    }
+
+    @Override
+    public Quote update(Quote quote) {
+        delete(quote.getId());
+        cache.add(quote);
+        store.save(cache);
+        return quote;
+    }
+
+    @Override
+    public void delete(UUID id) {
+        cache.removeIf(q -> id.equals(q.getId()));
+        store.save(cache);
+    }
+}

--- a/src/main/java/com/materiel/client/net/BackendTransport.java
+++ b/src/main/java/com/materiel/client/net/BackendTransport.java
@@ -1,0 +1,51 @@
+package com.materiel.client.net;
+
+import com.materiel.client.backend.invoker.ApiClient;
+import com.materiel.client.config.AppConfig;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+/**
+ * Configure le transport HTTP pour le SDK backend.
+ */
+public class BackendTransport {
+    private final ApiClient apiClient;
+
+    public BackendTransport(AppConfig config) {
+        this.apiClient = new ApiClient();
+        this.apiClient.setBasePath(config.getApiBaseUrl());
+
+        OkHttpClient.Builder builder = apiClient.getHttpClient().newBuilder()
+                .readTimeout(Duration.ofSeconds(30))
+                .callTimeout(Duration.ofSeconds(30));
+
+        final String token = config.getApiToken();
+        final String user = config.getApiBasicUser();
+        final String pass = config.getApiBasicPass();
+
+        if (token != null && !token.isEmpty()) {
+            builder.addInterceptor(chain -> addHeader(chain, "Authorization", "Bearer " + token));
+        } else if (user != null && pass != null) {
+            String basic = Base64.getEncoder().encodeToString((user + ":" + pass).getBytes(StandardCharsets.UTF_8));
+            builder.addInterceptor(chain -> addHeader(chain, "Authorization", "Basic " + basic));
+        }
+
+        this.apiClient.setHttpClient(builder.build());
+    }
+
+    private Response addHeader(Interceptor.Chain chain, String name, String value) throws IOException {
+        Request request = chain.request().newBuilder().addHeader(name, value).build();
+        return chain.proceed(request);
+    }
+
+    public ApiClient getApiClient() {
+        return apiClient;
+    }
+}

--- a/src/main/java/com/materiel/client/service/QuoteService.java
+++ b/src/main/java/com/materiel/client/service/QuoteService.java
@@ -1,0 +1,17 @@
+package com.materiel.client.service;
+
+import com.materiel.client.backend.model.Quote;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service de gestion des devis (quotes).
+ */
+public interface QuoteService {
+    List<Quote> list();
+    Quote get(UUID id);
+    Quote create(Quote quote);
+    Quote update(Quote quote);
+    void delete(UUID id);
+}

--- a/src/main/java/com/materiel/client/service/ServiceFactory.java
+++ b/src/main/java/com/materiel/client/service/ServiceFactory.java
@@ -5,18 +5,22 @@ import com.materiel.client.service.impl.ApiClientService;
 import com.materiel.client.service.impl.ApiDevisService;
 import com.materiel.client.service.impl.ApiInterventionService;
 import com.materiel.client.service.impl.ApiResourceService;
+import com.materiel.client.service.impl.backend.QuoteServiceBackend;
 import com.materiel.client.service.impl.MockClientService;
 import com.materiel.client.service.impl.MockDevisService;
 import com.materiel.client.service.impl.MockInterventionService;
 import com.materiel.client.service.impl.MockResourceService;
 import com.materiel.client.service.impl.MockCommandeService;
 import com.materiel.client.service.impl.MockBonLivraisonService;
+import com.materiel.client.mock.QuoteServiceMock;
 import com.materiel.client.mock.OrderServiceMock;
 import com.materiel.client.mock.DeliveryNoteServiceMock;
 import com.materiel.client.mock.InvoiceServiceMock;
 import com.materiel.client.mock.SequenceServiceMock;
+import com.materiel.client.net.BackendTransport;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import com.materiel.client.service.QuoteService;
 
 /**
  * Factory pour créer les services selon le mode configuré
@@ -33,6 +37,7 @@ public class ServiceFactory {
     private static DeliveryNoteService deliveryNoteService;
     private static InvoiceService invoiceService;
     private static SequenceService sequenceService;
+    private static QuoteService quoteService;
     
     public static ResourceService getResourceService() {
         if (resourceService == null) {
@@ -80,6 +85,19 @@ public class ServiceFactory {
             }
         }
         return clientService;
+    }
+
+    public static QuoteService getQuoteService() {
+        if (quoteService == null) {
+            AppConfig config = AppConfig.getInstance();
+            if (config.isBackendMode()) {
+                BackendTransport transport = new BackendTransport(config);
+                quoteService = new QuoteServiceBackend(transport.getApiClient());
+            } else {
+                quoteService = new QuoteServiceMock(dataDir());
+            }
+        }
+        return quoteService;
     }
     
     public static CommandeService getCommandeService() {
@@ -170,5 +188,6 @@ public class ServiceFactory {
         deliveryNoteService = null;
         invoiceService = null;
         sequenceService = null;
+        quoteService = null;
     }
 }

--- a/src/main/java/com/materiel/client/service/impl/backend/QuoteServiceBackend.java
+++ b/src/main/java/com/materiel/client/service/impl/backend/QuoteServiceBackend.java
@@ -1,0 +1,66 @@
+package com.materiel.client.service.impl.backend;
+
+import com.materiel.client.backend.api.QuotesApi;
+import com.materiel.client.backend.invoker.ApiClient;
+import com.materiel.client.backend.invoker.ApiException;
+import com.materiel.client.backend.model.Quote;
+import com.materiel.client.service.QuoteService;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Implémentation backend du service de devis.
+ */
+public class QuoteServiceBackend implements QuoteService {
+    private final QuotesApi api;
+
+    public QuoteServiceBackend(ApiClient client) {
+        this.api = new QuotesApi(client);
+    }
+
+    @Override
+    public List<Quote> list() {
+        try {
+            return api.listQuotes();
+        } catch (ApiException e) {
+            throw new RuntimeException("API error", e);
+        }
+    }
+
+    @Override
+    public Quote get(UUID id) {
+        try {
+            return api.getQuote(id);
+        } catch (ApiException e) {
+            throw new RuntimeException("API error", e);
+        }
+    }
+
+    @Override
+    public Quote create(Quote quote) {
+        try {
+            return api.createQuote(quote);
+        } catch (ApiException e) {
+            throw new RuntimeException("API error", e);
+        }
+    }
+
+    @Override
+    public Quote update(Quote quote) {
+        try {
+            return api.updateQuote(quote.getId(), quote);
+        } catch (ApiException e) {
+            throw new RuntimeException("API error", e);
+        }
+    }
+
+    @Override
+    public void delete(UUID id) {
+        try {
+            api.deleteQuote(id);
+        } catch (ApiException e) {
+            throw new RuntimeException("API error", e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,12 @@
-# Configuration application Swing Gestion Materiel 
-app.name=Gestion Materiel 
-app.version=1.0.0 
-log.level=INFO 
- 
-# Configuration UI 
-ui.theme=FlatLaf Light 
-ui.language=fr_FR 
+# Configuration application Swing Gestion Materiel
+app.name=Gestion Materiel
+app.version=1.0.0
+log.level=INFO
+
+# Configuration UI
+ui.theme=FlatLaf Light
+ui.language=fr_FR
+
+# Backend configuration
+app.mode=mock
+api.baseUrl=http://localhost:8080

--- a/src/test/java/com/materiel/client/service/backend/QuoteServiceBackendWireMockTest.java
+++ b/src/test/java/com/materiel/client/service/backend/QuoteServiceBackendWireMockTest.java
@@ -1,0 +1,98 @@
+package com.materiel.client.service.backend;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.materiel.client.backend.model.DocumentLine;
+import com.materiel.client.backend.model.Quote;
+import com.materiel.client.config.AppConfig;
+import com.materiel.client.service.QuoteService;
+import com.materiel.client.service.ServiceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests du QuoteServiceBackend avec WireMock.
+ */
+public class QuoteServiceBackendWireMockTest {
+    private WireMockServer server;
+
+    @BeforeEach
+    void setup() {
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server.start();
+        WireMock.configureFor("localhost", server.port());
+        System.setProperty("app.mode", "backend");
+        System.setProperty("api.baseUrl", server.baseUrl());
+        AppConfig.reset();
+        ServiceFactory.resetServices();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
+        System.clearProperty("app.mode");
+        System.clearProperty("api.baseUrl");
+        AppConfig.reset();
+        ServiceFactory.resetServices();
+    }
+
+    @Test
+    void testListAndCreateQuote() {
+        UUID quoteId = UUID.randomUUID();
+        UUID lineId = UUID.randomUUID();
+        String listBody = "[{'id':'"+quoteId+"','number':'Q-1','date':'2024-01-10','customerName':'Bob','lines':[]," +
+                "'totalHT':0,'totalTVA':0,'totalTTC':0,'status':'DRAFT'}]".replace(''','"');
+        server.stubFor(get(urlEqualTo("/api/v1/quotes"))
+                .willReturn(okJson(listBody)));
+
+        String postResp = ("{'id':'"+quoteId+"','number':'Q-1','date':'2024-01-10','customerName':'Bob',"+
+                "'lines':[{'id':'"+lineId+"','designation':'Item','unite':'u','quantite':1,"+
+                "'prixUnitaireHT':10,'remisePct':0,'tvaPct':20}],"+
+                "'totalHT':10,'totalTVA':2,'totalTTC':12,'status':'DRAFT'}").replace(''','"');
+        server.stubFor(post(urlEqualTo("/api/v1/quotes"))
+                .willReturn(aResponse().withStatus(201).withHeader("Content-Type","application/json").withBody(postResp)));
+        server.stubFor(put(urlEqualTo("/api/v1/quotes/"+quoteId))
+                .willReturn(okJson(postResp)));
+
+        QuoteService service = ServiceFactory.getQuoteService();
+        List<Quote> quotes = service.list();
+        assertEquals(1, quotes.size());
+        assertEquals(LocalDate.of(2024,1,10), quotes.get(0).getDate());
+
+        Quote q = new Quote();
+        q.setNumber("Q-1");
+        q.setDate(LocalDate.of(2024,1,10));
+        q.setCustomerName("Bob");
+        DocumentLine dl = new DocumentLine();
+        dl.setId(lineId);
+        dl.setDesignation("Item");
+        dl.setUnite("u");
+        dl.setQuantite(BigDecimal.ONE);
+        dl.setPrixUnitaireHT(new BigDecimal("10"));
+        dl.setRemisePct(BigDecimal.ZERO);
+        dl.setTvaPct(new BigDecimal("20"));
+        q.setLines(List.of(dl));
+        q.setTotalHT(new BigDecimal("10"));
+        q.setTotalTVA(new BigDecimal("2"));
+        q.setTotalTTC(new BigDecimal("12"));
+
+        Quote created = service.create(q);
+        assertEquals(new BigDecimal("12"), created.getTotalTTC());
+        service.update(created);
+
+        verify(postRequestedFor(urlEqualTo("/api/v1/quotes"))
+                .withRequestBody(matchingJsonPath("$.date", equalTo("2024-01-10")))
+                .withRequestBody(matchingJsonPath("$.lines[0].designation", equalTo("Item")))
+                .withRequestBody(matchingJsonPath("$.totalHT", equalTo(10.0))));
+    }
+}


### PR DESCRIPTION
## Summary
- integrate openapi generator and okhttp client
- wire backend QuoteService with new transport and config
- cover quote service with WireMock test

## Testing
- `mvn -q -DskipTests compile` *(fails: Network is unreachable)*
- `mvn -q -Dtest=QuoteServiceBackendWireMockTest test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2852b76a883309760c57c4afda8ec